### PR TITLE
Add `PvPool` and make pool telemetry snapshots public

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,14 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+- New `PvPool` type (accessible via `Microgrid::pv_pool`) exposing:
+  - `power()` — a `Formula<Power>` for the pool's aggregated power.
+  - `power_bounds()` — a `broadcast::Receiver<Vec<Bounds<Power>>>` tracking the pool's power bounds.
+  - `telemetry_snapshots()` — a `broadcast::Receiver<PvPoolSnapshot>` partitioning the pool's inverters into healthy and unhealthy sets.
+
+- `BatteryPool::telemetry_snapshots()` exposes the same per-component health partition (`BatteryPoolSnapshot`).
+
+- The pool telemetry trackers and snapshot types (`BatteryPoolSnapshot`, `PvPoolSnapshot`, `InverterBatteryGroup`, `InverterBatteryGroupStatus`) are now public and re-exported from the crate root.
 
 ## Bug Fixes
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub mod metric;
 pub(crate) mod wall_clock_timer;
 
 mod microgrid;
-pub use microgrid::{BatteryPool, Microgrid};
+pub use microgrid::{BatteryPool, Microgrid, PvPool};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub use client::test_utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,10 @@ pub mod metric;
 pub(crate) mod wall_clock_timer;
 
 mod microgrid;
-pub use microgrid::{BatteryPool, Microgrid, PvPool};
+pub use microgrid::{
+    BatteryPool, BatteryPoolSnapshot, BatteryPoolTelemetryTracker, InverterBatteryGroup,
+    InverterBatteryGroupStatus, Microgrid, PvPool, PvPoolSnapshot, PvPoolTelemetryTracker,
+};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub use client::test_utils;

--- a/src/microgrid.rs
+++ b/src/microgrid.rs
@@ -9,6 +9,7 @@ mod battery_bounds_tracker;
 mod battery_pool;
 pub use battery_pool::BatteryPool;
 
+mod pv_bounds_tracker;
 mod pv_pool;
 pub use pv_pool::PvPool;
 

--- a/src/microgrid.rs
+++ b/src/microgrid.rs
@@ -14,6 +14,11 @@ mod pv_pool;
 pub use pv_pool::PvPool;
 
 pub(crate) mod telemetry_tracker;
+pub use telemetry_tracker::battery_pool_telemetry_tracker::{
+    BatteryPoolSnapshot, BatteryPoolTelemetryTracker, InverterBatteryGroup,
+};
+pub use telemetry_tracker::inverter_battery_group_telemetry_tracker::InverterBatteryGroupStatus;
+pub use telemetry_tracker::pv_pool_telemetry_tracker::{PvPoolSnapshot, PvPoolTelemetryTracker};
 
 use crate::{Error, LogicalMeterConfig, LogicalMeterHandle, MicrogridClientHandle};
 

--- a/src/microgrid.rs
+++ b/src/microgrid.rs
@@ -7,6 +7,9 @@ mod battery_bounds_tracker;
 mod battery_pool;
 pub use battery_pool::BatteryPool;
 
+mod pv_pool;
+pub use pv_pool::PvPool;
+
 pub(crate) mod telemetry_tracker;
 
 use crate::{Error, LogicalMeterConfig, LogicalMeterHandle, MicrogridClientHandle};
@@ -63,6 +66,14 @@ impl Microgrid {
 
     pub fn battery_pool(&self, component_ids: Option<Vec<u64>>) -> Result<BatteryPool, Error> {
         BatteryPool::try_new(
+            component_ids.map(|ids| ids.into_iter().collect()),
+            self.client.clone(),
+            self.logical_meter.clone(),
+        )
+    }
+
+    pub fn pv_pool(&self, component_ids: Option<Vec<u64>>) -> Result<PvPool, Error> {
+        PvPool::try_new(
             component_ids.map(|ids| ids.into_iter().collect()),
             self.client.clone(),
             self.logical_meter.clone(),

--- a/src/microgrid.rs
+++ b/src/microgrid.rs
@@ -3,6 +3,8 @@
 
 //! High-level interface for the Microgrid API.
 
+mod bounds_aggregation;
+
 mod battery_bounds_tracker;
 mod battery_pool;
 pub use battery_pool::BatteryPool;

--- a/src/microgrid/battery_bounds_tracker.rs
+++ b/src/microgrid/battery_bounds_tracker.rs
@@ -19,15 +19,13 @@
 //!   aggregated bounds are intersected.
 //! * Groups within a pool are in parallel — their bounds are added together.
 
-use std::collections::HashMap;
 use std::marker::PhantomData;
 
 use tokio::sync::broadcast;
 
 use crate::bounds::{combine_parallel_sets, intersect_bounds_sets};
-use crate::client::proto::common::{
-    metrics::Bounds as PbBounds, microgrid::electrical_components::ElectricalComponentTelemetry,
-};
+use crate::client::proto::common::metrics::Bounds as PbBounds;
+use crate::microgrid::bounds_aggregation::aggregate_parallel;
 use crate::microgrid::telemetry_tracker::battery_pool_telemetry_tracker::BatteryPoolSnapshot;
 use crate::{Bounds, metric::Metric};
 
@@ -106,39 +104,6 @@ where
                 combine_parallel_sets(&acc, &group_bounds)
             })
     }
-}
-
-/// Combines the bounds of every component in the map as if they were wired
-/// in parallel. Components that don't report the metric `M` are skipped.
-fn aggregate_parallel<M: Metric>(
-    components: &HashMap<u64, ElectricalComponentTelemetry>,
-) -> Vec<Bounds<M::QuantityType>>
-where
-    Bounds<M::QuantityType>: From<PbBounds>,
-{
-    components
-        .values()
-        .filter_map(extract_metric_bounds::<M>)
-        .fold(Vec::new(), |acc, bounds| {
-            combine_parallel_sets(&acc, &bounds)
-        })
-}
-
-fn extract_metric_bounds<M: Metric>(
-    telemetry: &ElectricalComponentTelemetry,
-) -> Option<Vec<Bounds<M::QuantityType>>>
-where
-    Bounds<M::QuantityType>: From<PbBounds>,
-{
-    telemetry.metric_samples.iter().find_map(|sample| {
-        (sample.metric == M::METRIC as i32).then(|| {
-            sample
-                .bounds
-                .iter()
-                .map(|b| Bounds::from(*b))
-                .collect::<Vec<_>>()
-        })
-    })
 }
 
 #[cfg(test)]

--- a/src/microgrid/battery_pool.rs
+++ b/src/microgrid/battery_pool.rs
@@ -119,7 +119,7 @@ impl BatteryPool {
     ///
     /// Reuses the running tracker if one exists and still has active receivers
     /// (including any held by a bounds tracker); otherwise starts a new one.
-    pub(crate) fn telemetry_snapshots(&mut self) -> broadcast::Receiver<BatteryPoolSnapshot> {
+    pub fn telemetry_snapshots(&mut self) -> broadcast::Receiver<BatteryPoolSnapshot> {
         if let Some(tx) = self
             .snapshot_tx
             .as_ref()

--- a/src/microgrid/bounds_aggregation.rs
+++ b/src/microgrid/bounds_aggregation.rs
@@ -1,0 +1,49 @@
+// License: MIT
+// Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+//! Helpers for aggregating per-component metric bounds into pool-level bounds.
+//!
+//! These are shared by the per-pool bounds trackers (e.g. battery and PV),
+//! which read a target metric's bounds from each healthy component and combine
+//! the components wired in parallel.
+
+use std::collections::HashMap;
+
+use crate::bounds::combine_parallel_sets;
+use crate::client::proto::common::{
+    metrics::Bounds as PbBounds, microgrid::electrical_components::ElectricalComponentTelemetry,
+};
+use crate::{Bounds, metric::Metric};
+
+/// Combines the bounds of every component in the map as if they were wired
+/// in parallel. Components that don't report the metric `M` are skipped.
+pub(crate) fn aggregate_parallel<M: Metric>(
+    components: &HashMap<u64, ElectricalComponentTelemetry>,
+) -> Vec<Bounds<M::QuantityType>>
+where
+    Bounds<M::QuantityType>: From<PbBounds>,
+{
+    components
+        .values()
+        .filter_map(extract_metric_bounds::<M>)
+        .fold(Vec::new(), |acc, bounds| {
+            combine_parallel_sets(&acc, &bounds)
+        })
+}
+
+fn extract_metric_bounds<M: Metric>(
+    telemetry: &ElectricalComponentTelemetry,
+) -> Option<Vec<Bounds<M::QuantityType>>>
+where
+    Bounds<M::QuantityType>: From<PbBounds>,
+{
+    telemetry.metric_samples.iter().find_map(|sample| {
+        (sample.metric == M::METRIC as i32).then(|| {
+            sample
+                .bounds
+                .iter()
+                .map(|b| Bounds::from(*b))
+                .collect::<Vec<_>>()
+        })
+    })
+}

--- a/src/microgrid/pv_bounds_tracker.rs
+++ b/src/microgrid/pv_bounds_tracker.rs
@@ -1,0 +1,228 @@
+// License: MIT
+// Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+//! Bounds tracker for a pool of PV inverters.
+//!
+//! Subscribes to a [`PvPoolSnapshot`] stream and, for each update, extracts the
+//! bounds of a target metric from every healthy PV inverter and aggregates them
+//! into a single pool-level set of bounds.
+//!
+//! PV inverters in a pool are wired in parallel, so their bounds are simply
+//! added together.
+
+use std::marker::PhantomData;
+
+use tokio::sync::broadcast;
+
+use crate::client::proto::common::metrics::Bounds as PbBounds;
+use crate::microgrid::bounds_aggregation::aggregate_parallel;
+use crate::microgrid::telemetry_tracker::pv_pool_telemetry_tracker::PvPoolSnapshot;
+use crate::{Bounds, metric::Metric};
+
+/// Tracks and aggregates power bounds for a PV pool.
+///
+/// `M` is the metric used to read bounds from the PV inverters (e.g.
+/// `AcPowerActive`).
+pub(crate) struct PvPoolBoundsTracker<M: Metric> {
+    pool_status_rx: broadcast::Receiver<PvPoolSnapshot>,
+    pool_bounds_tx: broadcast::Sender<Vec<Bounds<M::QuantityType>>>,
+    _marker: PhantomData<M>,
+}
+
+impl<M> PvPoolBoundsTracker<M>
+where
+    M: Metric,
+    Bounds<M::QuantityType>: From<PbBounds>,
+{
+    pub(crate) fn new(
+        pool_status_rx: broadcast::Receiver<PvPoolSnapshot>,
+        pool_bounds_tx: broadcast::Sender<Vec<Bounds<M::QuantityType>>>,
+    ) -> Self {
+        Self {
+            pool_status_rx,
+            pool_bounds_tx,
+            _marker: PhantomData,
+        }
+    }
+
+    pub(crate) async fn run(mut self) {
+        loop {
+            match self.pool_status_rx.recv().await {
+                Ok(pool_status) => {
+                    let bounds = Self::compute_pool_bounds(&pool_status);
+                    if self.pool_bounds_tx.send(bounds).is_err() {
+                        tracing::debug!(
+                            "No receivers for {} PV bounds tracker; shutting down.",
+                            M::str_name(),
+                        );
+                        break;
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    tracing::warn!(
+                        "{} PV bounds tracker lagged by {n} pool status updates.",
+                        M::str_name(),
+                    );
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    tracing::error!(
+                        "Pool status channel closed; {} PV bounds tracker shutting down.",
+                        M::str_name(),
+                    );
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Aggregates the bounds of every healthy PV inverter in the pool. The
+    /// inverters are wired in parallel, so their bounds combine in parallel.
+    fn compute_pool_bounds(status: &PvPoolSnapshot) -> Vec<Bounds<M::QuantityType>> {
+        aggregate_parallel::<M>(&status.healthy_inverters)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::Bounds;
+    use crate::client::proto::common::metrics::{
+        Bounds as PbBounds, Metric as MetricPb, MetricSample,
+    };
+    use crate::client::proto::common::microgrid::electrical_components::ElectricalComponentTelemetry;
+    use crate::metric::AcPowerActive;
+    use crate::microgrid::telemetry_tracker::pv_pool_telemetry_tracker::PvPoolSnapshot;
+    use crate::quantity::Power;
+
+    use super::PvPoolBoundsTracker;
+
+    fn telem_with_power_bounds(
+        id: u64,
+        bounds: Vec<(Option<f32>, Option<f32>)>,
+    ) -> ElectricalComponentTelemetry {
+        ElectricalComponentTelemetry {
+            electrical_component_id: id,
+            metric_samples: vec![MetricSample {
+                sample_time: None,
+                metric: MetricPb::AcPowerActive as i32,
+                value: None,
+                bounds: bounds
+                    .into_iter()
+                    .map(|(lower, upper)| PbBounds { lower, upper })
+                    .collect(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    /// Builds a snapshot whose healthy set holds the given telemetry, keyed by
+    /// component ID, and an empty unhealthy set.
+    fn healthy_snapshot(healthy: Vec<ElectricalComponentTelemetry>) -> PvPoolSnapshot {
+        let healthy = healthy
+            .into_iter()
+            .map(|t| (t.electrical_component_id, t))
+            .collect();
+        PvPoolSnapshot {
+            healthy_inverters: healthy,
+            unhealthy_inverters: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn single_inverter_uses_its_bounds() {
+        let snap = healthy_snapshot(vec![telem_with_power_bounds(
+            10,
+            vec![(Some(-1000.0), Some(0.0))],
+        )]);
+        let bounds = PvPoolBoundsTracker::<AcPowerActive>::compute_pool_bounds(&snap);
+        assert_eq!(
+            bounds,
+            vec![Bounds::new(
+                Some(Power::from_watts(-1000.0)),
+                Some(Power::from_watts(0.0))
+            )]
+        );
+    }
+
+    #[test]
+    fn parallel_inverters_add() {
+        let snap = healthy_snapshot(vec![
+            telem_with_power_bounds(10, vec![(Some(-1000.0), Some(0.0))]),
+            telem_with_power_bounds(11, vec![(Some(-2000.0), Some(0.0))]),
+        ]);
+        let bounds = PvPoolBoundsTracker::<AcPowerActive>::compute_pool_bounds(&snap);
+        assert_eq!(
+            bounds,
+            vec![Bounds::new(
+                Some(Power::from_watts(-3000.0)),
+                Some(Power::from_watts(0.0))
+            )]
+        );
+    }
+
+    #[test]
+    fn empty_pool_yields_empty_bounds() {
+        let snap = healthy_snapshot(vec![]);
+        let bounds = PvPoolBoundsTracker::<AcPowerActive>::compute_pool_bounds(&snap);
+        assert!(bounds.is_empty());
+    }
+
+    /// Only healthy inverters contribute to the pool bounds; unhealthy ones are
+    /// ignored even when their last telemetry carried bounds.
+    #[test]
+    fn unhealthy_inverters_are_excluded() {
+        let healthy = [telem_with_power_bounds(
+            10,
+            vec![(Some(-1000.0), Some(0.0))],
+        )]
+        .into_iter()
+        .map(|t| (t.electrical_component_id, t))
+        .collect();
+        let mut unhealthy = HashMap::new();
+        unhealthy.insert(
+            11,
+            Some(telem_with_power_bounds(
+                11,
+                vec![(Some(-9000.0), Some(0.0))],
+            )),
+        );
+        let snap = PvPoolSnapshot {
+            healthy_inverters: healthy,
+            unhealthy_inverters: unhealthy,
+        };
+
+        let bounds = PvPoolBoundsTracker::<AcPowerActive>::compute_pool_bounds(&snap);
+        assert_eq!(
+            bounds,
+            vec![Bounds::new(
+                Some(Power::from_watts(-1000.0)),
+                Some(Power::from_watts(0.0))
+            )]
+        );
+    }
+
+    /// An inverter that reports a different metric carries no active-power
+    /// bounds, so it contributes nothing to the pool aggregate.
+    #[test]
+    fn inverter_without_matching_metric_contributes_nothing() {
+        let other = ElectricalComponentTelemetry {
+            electrical_component_id: 10,
+            metric_samples: vec![MetricSample {
+                sample_time: None,
+                metric: MetricPb::AcVoltage as i32,
+                value: None,
+                bounds: vec![PbBounds {
+                    lower: Some(0.0),
+                    upper: Some(1.0),
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let snap = healthy_snapshot(vec![other]);
+        let bounds = PvPoolBoundsTracker::<AcPowerActive>::compute_pool_bounds(&snap);
+        assert!(bounds.is_empty());
+    }
+}

--- a/src/microgrid/pv_pool.rs
+++ b/src/microgrid/pv_pool.rs
@@ -1,0 +1,149 @@
+// License: MIT
+// Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+//! Representation of a pool of PV inverters in the microgrid.
+
+use std::collections::BTreeSet;
+
+use crate::{Error, Formula, LogicalMeterHandle, MicrogridClientHandle, metric, quantity::Power};
+
+/// An interface for abstracting over a pool of PV inverters in the microgrid.
+pub struct PvPool {
+    component_ids: Option<BTreeSet<u64>>,
+    client: MicrogridClientHandle,
+    logical_meter: LogicalMeterHandle,
+}
+
+impl PvPool {
+    /// Creates a new `PvPool` instance with the given component IDs, client and
+    /// logical meter handles.
+    ///
+    /// When `component_ids` is `Some`, every ID must refer to a PV inverter in
+    /// the component graph; otherwise an error is returned. When it is `None`,
+    /// the pool covers all PV inverters in the microgrid.
+    pub(crate) fn try_new(
+        component_ids: Option<BTreeSet<u64>>,
+        client: MicrogridClientHandle,
+        logical_meter: LogicalMeterHandle,
+    ) -> Result<Self, Error> {
+        let this = Self {
+            component_ids,
+            client,
+            logical_meter,
+        };
+        if let Some(ids) = &this.component_ids {
+            if ids.is_empty() {
+                let e = "component_ids cannot be an empty set".to_string();
+                tracing::error!("{e}");
+                return Err(Error::invalid_component(e));
+            }
+            // Validate that all provided IDs correspond to PV inverters in the
+            // graph.
+            if !ids.is_subset(&this.get_all_pv_inverter_ids()) {
+                let e = format!("All component_ids {:?} must be PV inverters.", ids);
+                tracing::error!("{e}");
+                return Err(Error::invalid_component(e));
+            }
+        }
+        Ok(this)
+    }
+
+    fn get_all_pv_inverter_ids(&self) -> BTreeSet<u64> {
+        self.logical_meter
+            .graph()
+            .components()
+            .filter(|c| c.is_pv_inverter())
+            .map(|c| c.id)
+            .collect()
+    }
+
+    /// Returns a formula for the active power of the PV pool.
+    pub fn power(&mut self) -> Result<Formula<Power>, Error> {
+        self.logical_meter
+            .pv::<metric::AcPowerActive>(self.component_ids.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use chrono::TimeDelta;
+
+    use super::PvPool;
+    use crate::{
+        LogicalMeterConfig, LogicalMeterHandle, MicrogridClientHandle,
+        client::test_utils::{MockComponent, MockMicrogridApiClient},
+    };
+
+    /// Builds client and logical-meter handles backed by the given mock graph.
+    async fn handles(graph: MockComponent) -> (MicrogridClientHandle, LogicalMeterHandle) {
+        let api = MockMicrogridApiClient::new(graph);
+        let client = MicrogridClientHandle::new_from_client(api);
+        let lm = LogicalMeterHandle::try_new(
+            client.clone(),
+            LogicalMeterConfig::new(TimeDelta::try_seconds(1).unwrap()),
+        )
+        .await
+        .unwrap();
+        (client, lm)
+    }
+
+    /// grid → meter → [pv meter → pv_inverter(4), pv_inverter(5)],
+    ///                 [battery meter → battery_inverter(7) → battery(8)]
+    fn graph() -> MockComponent {
+        MockComponent::grid(1).with_children(vec![MockComponent::meter(2).with_children(vec![
+            MockComponent::meter(3).with_children(vec![
+                MockComponent::pv_inverter(4),
+                MockComponent::pv_inverter(5),
+            ]),
+            MockComponent::meter(6).with_children(vec![
+                MockComponent::battery_inverter(7).with_children(vec![MockComponent::battery(8)]),
+            ]),
+        ])])
+    }
+
+    #[tokio::test]
+    async fn try_new_rejects_empty_component_ids() {
+        let (client, lm) = handles(graph()).await;
+        let err = PvPool::try_new(Some(BTreeSet::new()), client, lm)
+            .err()
+            .expect("empty component_ids should be rejected");
+        assert!(err.to_string().contains("empty"), "unexpected error: {err}");
+    }
+
+    #[tokio::test]
+    async fn try_new_rejects_non_pv_component_ids() {
+        let (client, lm) = handles(graph()).await;
+        // 7 is a battery inverter and 8 a battery — neither is a PV inverter.
+        let err = PvPool::try_new(Some([4, 7, 8].into()), client, lm)
+            .err()
+            .expect("non-PV component_ids should be rejected");
+        assert!(
+            err.to_string().contains("must be PV inverters"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn power_formula_for_explicit_pv_inverters() {
+        let (client, lm) = handles(graph()).await;
+        let mut pool = PvPool::try_new(Some([4, 5].into()), client, lm).unwrap();
+        let formula = pool.power().unwrap();
+        assert_eq!(
+            formula.to_string(),
+            "METRIC_AC_POWER_ACTIVE::(COALESCE(#3, COALESCE(#5, 0.0) + COALESCE(#4, 0.0)))"
+        );
+    }
+
+    #[tokio::test]
+    async fn power_formula_for_all_pv_inverters() {
+        let (client, lm) = handles(graph()).await;
+        let mut pool = PvPool::try_new(None, client, lm).unwrap();
+        let formula = pool.power().unwrap();
+        assert_eq!(
+            formula.to_string(),
+            "METRIC_AC_POWER_ACTIVE::(COALESCE(#3, COALESCE(#5, 0.0) + COALESCE(#4, 0.0)))"
+        );
+    }
+}

--- a/src/microgrid/pv_pool.rs
+++ b/src/microgrid/pv_pool.rs
@@ -9,11 +9,12 @@ use std::collections::{BTreeSet, HashSet};
 use std::time::Duration;
 
 use crate::{
-    Error, Formula, LogicalMeterHandle, MicrogridClientHandle,
+    Bounds, Error, Formula, LogicalMeterHandle, MicrogridClientHandle,
     client::proto::common::microgrid::electrical_components::ElectricalComponentStateCode,
     metric,
-    microgrid::telemetry_tracker::pv_pool_telemetry_tracker::{
-        PvPoolSnapshot, PvPoolTelemetryTracker,
+    microgrid::{
+        pv_bounds_tracker::PvPoolBoundsTracker,
+        telemetry_tracker::pv_pool_telemetry_tracker::{PvPoolSnapshot, PvPoolTelemetryTracker},
     },
     quantity::Power,
 };
@@ -24,6 +25,7 @@ pub struct PvPool {
     client: MicrogridClientHandle,
     logical_meter: LogicalMeterHandle,
     snapshot_tx: Option<broadcast::WeakSender<PvPoolSnapshot>>,
+    bounds_tx: Option<broadcast::WeakSender<Vec<Bounds<Power>>>>,
 }
 
 impl PvPool {
@@ -43,6 +45,7 @@ impl PvPool {
             client,
             logical_meter,
             snapshot_tx: None,
+            bounds_tx: None,
         };
         if let Some(ids) = &this.component_ids {
             if ids.is_empty() {
@@ -82,6 +85,29 @@ impl PvPool {
     pub fn power(&mut self) -> Result<Formula<Power>, Error> {
         self.logical_meter
             .pv::<metric::AcPowerActive>(self.component_ids.clone())
+    }
+
+    /// Returns a receiver for the aggregated active-power bounds of the pool,
+    /// updated on each snapshot.
+    ///
+    /// Reuses the running bounds tracker if one exists and still has active
+    /// receivers; otherwise starts a new one (which also starts or reuses the
+    /// underlying telemetry tracker).
+    pub fn power_bounds(&mut self) -> broadcast::Receiver<Vec<Bounds<Power>>> {
+        if let Some(tx) = self
+            .bounds_tx
+            .as_ref()
+            .and_then(broadcast::WeakSender::upgrade)
+            && tx.receiver_count() > 0
+        {
+            return tx.subscribe();
+        }
+        let snapshot_rx = self.telemetry_snapshots();
+        let (tx, rx) = broadcast::channel(100);
+        self.bounds_tx = Some(tx.downgrade());
+        let tracker = PvPoolBoundsTracker::<metric::AcPowerActive>::new(snapshot_rx, tx);
+        tokio::spawn(tracker.run());
+        rx
     }
 
     /// Returns a receiver for a stream of [`PvPoolSnapshot`] values, each

--- a/src/microgrid/pv_pool.rs
+++ b/src/microgrid/pv_pool.rs
@@ -116,7 +116,7 @@ impl PvPool {
     ///
     /// Reuses the running tracker if one exists and still has active receivers
     /// (including any held by a bounds tracker); otherwise starts a new one.
-    pub(crate) fn telemetry_snapshots(&mut self) -> broadcast::Receiver<PvPoolSnapshot> {
+    pub fn telemetry_snapshots(&mut self) -> broadcast::Receiver<PvPoolSnapshot> {
         if let Some(tx) = self
             .snapshot_tx
             .as_ref()

--- a/src/microgrid/pv_pool.rs
+++ b/src/microgrid/pv_pool.rs
@@ -3,15 +3,27 @@
 
 //! Representation of a pool of PV inverters in the microgrid.
 
-use std::collections::BTreeSet;
+use tokio::sync::broadcast;
 
-use crate::{Error, Formula, LogicalMeterHandle, MicrogridClientHandle, metric, quantity::Power};
+use std::collections::{BTreeSet, HashSet};
+use std::time::Duration;
+
+use crate::{
+    Error, Formula, LogicalMeterHandle, MicrogridClientHandle,
+    client::proto::common::microgrid::electrical_components::ElectricalComponentStateCode,
+    metric,
+    microgrid::telemetry_tracker::pv_pool_telemetry_tracker::{
+        PvPoolSnapshot, PvPoolTelemetryTracker,
+    },
+    quantity::Power,
+};
 
 /// An interface for abstracting over a pool of PV inverters in the microgrid.
 pub struct PvPool {
     component_ids: Option<BTreeSet<u64>>,
     client: MicrogridClientHandle,
     logical_meter: LogicalMeterHandle,
+    snapshot_tx: Option<broadcast::WeakSender<PvPoolSnapshot>>,
 }
 
 impl PvPool {
@@ -30,6 +42,7 @@ impl PvPool {
             component_ids,
             client,
             logical_meter,
+            snapshot_tx: None,
         };
         if let Some(ids) = &this.component_ids {
             if ids.is_empty() {
@@ -57,10 +70,53 @@ impl PvPool {
             .collect()
     }
 
+    pub(crate) fn get_pv_inverter_ids(&self) -> BTreeSet<u64> {
+        if let Some(ids) = &self.component_ids {
+            ids.clone()
+        } else {
+            self.get_all_pv_inverter_ids()
+        }
+    }
+
     /// Returns a formula for the active power of the PV pool.
     pub fn power(&mut self) -> Result<Formula<Power>, Error> {
         self.logical_meter
             .pv::<metric::AcPowerActive>(self.component_ids.clone())
+    }
+
+    /// Returns a receiver for a stream of [`PvPoolSnapshot`] values, each
+    /// reflecting the latest inverter telemetry partitioned into healthy and
+    /// unhealthy sets.
+    ///
+    /// Reuses the running tracker if one exists and still has active receivers
+    /// (including any held by a bounds tracker); otherwise starts a new one.
+    pub(crate) fn telemetry_snapshots(&mut self) -> broadcast::Receiver<PvPoolSnapshot> {
+        if let Some(tx) = self
+            .snapshot_tx
+            .as_ref()
+            .and_then(broadcast::WeakSender::upgrade)
+            && tx.receiver_count() > 0
+        {
+            return tx.subscribe();
+        }
+        let (tx, rx) = broadcast::channel(100);
+        self.snapshot_tx = Some(tx.downgrade());
+        let tracker = PvPoolTelemetryTracker::new(
+            self.get_pv_inverter_ids(),
+            Duration::from_secs(10),
+            // Operational states in which a PV inverter is alive and
+            // reporting usable telemetry: producing (Discharging), or idle
+            // and ready (Ready / Standby).
+            HashSet::from([
+                ElectricalComponentStateCode::Ready,
+                ElectricalComponentStateCode::Standby,
+                ElectricalComponentStateCode::Discharging,
+            ]),
+            self.client.clone(),
+            tx,
+        );
+        tokio::spawn(tracker.run());
+        rx
     }
 }
 

--- a/src/microgrid/pv_pool.rs
+++ b/src/microgrid/pv_pool.rs
@@ -2,6 +2,15 @@
 // Copyright © 2026 Frequenz Energy-as-a-Service GmbH
 
 //! Representation of a pool of PV inverters in the microgrid.
+//!
+//! A [`PvPool`] aggregates a set of PV inverters — either an explicit subset or
+//! every PV inverter in the microgrid — and exposes their combined active
+//! power, their aggregated active-power bounds, and a health-partitioned
+//! telemetry snapshot stream.
+//!
+//! Obtain one from [`Microgrid::pv_pool`]; see [`PvPool`] for a usage example.
+//!
+//! [`Microgrid::pv_pool`]: crate::Microgrid::pv_pool
 
 use tokio::sync::broadcast;
 
@@ -19,7 +28,49 @@ use crate::{
     quantity::Power,
 };
 
-/// An interface for abstracting over a pool of PV inverters in the microgrid.
+/// A pool of PV inverters in the microgrid.
+///
+/// Created with [`Microgrid::pv_pool`][mg], passing either an explicit set of PV
+/// inverter component IDs or `None` to cover every PV inverter in the microgrid.
+/// It exposes:
+///
+/// - [`power`](Self::power) — a [`Formula`] for the pool's aggregate active
+///   power;
+/// - [`power_bounds`](Self::power_bounds) — a stream of the pool's aggregated
+///   active-power bounds;
+/// - [`telemetry_snapshots`](Self::telemetry_snapshots) — a stream of
+///   [`PvPoolSnapshot`]s partitioning the inverters into healthy and unhealthy
+///   sets.
+///
+/// The bounds and snapshot streams share a telemetry tracker that is started on
+/// first use and reused while it still has live receivers.
+///
+/// # Example
+///
+/// ```no_run
+/// # async fn example() -> Result<(), frequenz_microgrid::Error> {
+/// use chrono::TimeDelta;
+/// use frequenz_microgrid::{LogicalMeterConfig, Microgrid};
+///
+/// let microgrid = Microgrid::try_new(
+///     "grpc://localhost:50051",
+///     LogicalMeterConfig::new(TimeDelta::try_seconds(1).unwrap()),
+/// )
+/// .await?;
+///
+/// // A pool over every PV inverter in the microgrid.
+/// let mut pv_pool = microgrid.pv_pool(None)?;
+///
+/// // Subscribe to the pool's aggregated active-power bounds.
+/// let mut bounds_rx = pv_pool.power_bounds();
+/// while let Ok(bounds) = bounds_rx.recv().await {
+///     println!("PV pool active-power bounds: {bounds:?}");
+/// }
+/// # Ok(())
+/// # }
+/// ```
+///
+/// [mg]: crate::Microgrid::pv_pool
 pub struct PvPool {
     component_ids: Option<BTreeSet<u64>>,
     client: MicrogridClientHandle,

--- a/src/microgrid/telemetry_tracker.rs
+++ b/src/microgrid/telemetry_tracker.rs
@@ -10,3 +10,4 @@
 pub(crate) mod battery_pool_telemetry_tracker;
 pub(crate) mod component_telemetry_tracker;
 pub(crate) mod inverter_battery_group_telemetry_tracker;
+pub(crate) mod pv_pool_telemetry_tracker;

--- a/src/microgrid/telemetry_tracker/battery_pool_telemetry_tracker.rs
+++ b/src/microgrid/telemetry_tracker/battery_pool_telemetry_tracker.rs
@@ -20,7 +20,7 @@ use crate::{
 /// M inverters in parallel on the AC side, N batteries in parallel on the DC
 /// side, with the inverter side in series with the battery side.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub(crate) struct InverterBatteryGroup {
+pub struct InverterBatteryGroup {
     pub inverter_ids: BTreeSet<u64>,
     pub battery_ids: BTreeSet<u64>,
 }
@@ -35,10 +35,10 @@ impl InverterBatteryGroup {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) struct BatteryPoolSnapshot(HashMap<InverterBatteryGroup, InverterBatteryGroupStatus>);
+pub struct BatteryPoolSnapshot(HashMap<InverterBatteryGroup, InverterBatteryGroupStatus>);
 
 impl BatteryPoolSnapshot {
-    pub(crate) fn groups(&self) -> &HashMap<InverterBatteryGroup, InverterBatteryGroupStatus> {
+    pub fn groups(&self) -> &HashMap<InverterBatteryGroup, InverterBatteryGroupStatus> {
         &self.0
     }
 }
@@ -47,7 +47,7 @@ impl BatteryPoolSnapshot {
 /// a [`BatteryPoolSnapshot`] whenever any component's telemetry or health
 /// classification changes.
 #[derive(Clone)]
-pub(crate) struct BatteryPoolTelemetryTracker {
+pub struct BatteryPoolTelemetryTracker {
     component_ids: BTreeSet<u64>,
     component_pool_status_tx: tokio::sync::broadcast::Sender<BatteryPoolSnapshot>,
     missing_data_tolerance: Duration,

--- a/src/microgrid/telemetry_tracker/battery_pool_telemetry_tracker.rs
+++ b/src/microgrid/telemetry_tracker/battery_pool_telemetry_tracker.rs
@@ -179,8 +179,17 @@ impl BatteryPoolTelemetryTracker {
 
         loop {
             tokio::select! {
-                Some((group_ids, status)) = component_status_rx.recv() => {
-                    inverter_battery_group_data.insert(group_ids, status);
+                maybe_status = component_status_rx.recv() => {
+                    match maybe_status {
+                        Some((group_ids, status)) => {
+                            inverter_battery_group_data.insert(group_ids, status);
+                        }
+                        // Every group tracker has exited and dropped its sender,
+                        // so no further updates will arrive. The `interval.tick()`
+                        // arm never disables, so the `select!` `else` can never
+                        // run; break here instead.
+                        None => break,
+                    }
                 },
                 _ = interval.tick() => {
                     if last_sent_status.as_ref() == Some(&inverter_battery_group_data) {
@@ -195,7 +204,6 @@ impl BatteryPoolTelemetryTracker {
                     }
                     last_sent_status = Some(inverter_battery_group_data.clone());
                 },
-                else => break,
             }
         }
 

--- a/src/microgrid/telemetry_tracker/inverter_battery_group_telemetry_tracker.rs
+++ b/src/microgrid/telemetry_tracker/inverter_battery_group_telemetry_tracker.rs
@@ -52,7 +52,7 @@ pub(crate) struct InverterBatteryGroupTelemetryTracker {
 /// sample has been received yet. Consumers can use the telemetry (including
 /// per-metric bounds) directly without subscribing to the raw streams again.
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) struct InverterBatteryGroupStatus {
+pub struct InverterBatteryGroupStatus {
     pub healthy_inverters: HashMap<u64, ElectricalComponentTelemetry>,
     pub healthy_batteries: HashMap<u64, ElectricalComponentTelemetry>,
     pub unhealthy_inverters: HashMap<u64, Option<ElectricalComponentTelemetry>>,

--- a/src/microgrid/telemetry_tracker/pv_pool_telemetry_tracker.rs
+++ b/src/microgrid/telemetry_tracker/pv_pool_telemetry_tracker.rs
@@ -107,16 +107,21 @@ impl PvPoolTelemetryTracker {
 
         loop {
             tokio::select! {
-                Some(status) = status_rx.recv() => {
-                    match status {
-                        ComponentHealthStatus::Healthy(id, data) => {
+                maybe_status = status_rx.recv() => {
+                    match maybe_status {
+                        Some(ComponentHealthStatus::Healthy(id, data)) => {
                             healthy_inverters.insert(id, data);
                             unhealthy_inverters.remove(&id);
                         }
-                        ComponentHealthStatus::Unhealthy(id, data) => {
+                        Some(ComponentHealthStatus::Unhealthy(id, data)) => {
                             unhealthy_inverters.insert(id, data);
                             healthy_inverters.remove(&id);
                         }
+                        // Every component tracker has exited and dropped its
+                        // sender, so no further updates will arrive. The
+                        // `interval.tick()` arm never disables, so the `select!`
+                        // `else` can never run; break here instead.
+                        None => break,
                     }
                 },
                 _ = interval.tick() => {
@@ -138,7 +143,6 @@ impl PvPoolTelemetryTracker {
                     }
                     last_sent = Some(snapshot);
                 },
-                else => break,
             }
         }
 

--- a/src/microgrid/telemetry_tracker/pv_pool_telemetry_tracker.rs
+++ b/src/microgrid/telemetry_tracker/pv_pool_telemetry_tracker.rs
@@ -32,7 +32,7 @@ use super::component_telemetry_tracker::{ComponentHealthStatus, ComponentTelemet
 /// sample has been received yet. Consumers can use the telemetry (including
 /// per-metric bounds) directly without subscribing to the raw streams again.
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) struct PvPoolSnapshot {
+pub struct PvPoolSnapshot {
     pub healthy_inverters: HashMap<u64, ElectricalComponentTelemetry>,
     pub unhealthy_inverters: HashMap<u64, Option<ElectricalComponentTelemetry>>,
 }
@@ -41,7 +41,7 @@ pub(crate) struct PvPoolSnapshot {
 /// [`PvPoolSnapshot`] whenever any inverter's telemetry or health
 /// classification changes.
 #[derive(Clone)]
-pub(crate) struct PvPoolTelemetryTracker {
+pub struct PvPoolTelemetryTracker {
     component_ids: BTreeSet<u64>,
     component_pool_status_tx: broadcast::Sender<PvPoolSnapshot>,
     missing_data_tolerance: Duration,

--- a/src/microgrid/telemetry_tracker/pv_pool_telemetry_tracker.rs
+++ b/src/microgrid/telemetry_tracker/pv_pool_telemetry_tracker.rs
@@ -1,0 +1,317 @@
+// License: MIT
+// Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+//! A telemetry tracker for a pool of PV inverters.
+//!
+//! The tracker spawns a [`ComponentTelemetryTracker`] per inverter and emits a
+//! [`PvPoolSnapshot`], partitioning the inverters into healthy and unhealthy
+//! sets, whenever any inverter's telemetry or health classification changes.
+
+use std::{
+    collections::{BTreeSet, HashMap, HashSet},
+    time::Duration,
+};
+
+use tokio::sync::{broadcast, mpsc};
+
+use crate::{
+    Error, MicrogridClientHandle,
+    client::proto::common::microgrid::electrical_components::{
+        ElectricalComponentStateCode, ElectricalComponentTelemetry,
+    },
+};
+
+use super::component_telemetry_tracker::{ComponentHealthStatus, ComponentTelemetryTracker};
+
+/// A snapshot of a PV pool's inverters, partitioned by health status and
+/// annotated with the latest telemetry sample for each.
+///
+/// `healthy_inverters` holds the most recent [`ElectricalComponentTelemetry`]
+/// observed for each healthy inverter. `unhealthy_inverters` holds the last
+/// telemetry observed before the inverter became unhealthy, or `None` if no
+/// sample has been received yet. Consumers can use the telemetry (including
+/// per-metric bounds) directly without subscribing to the raw streams again.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct PvPoolSnapshot {
+    pub healthy_inverters: HashMap<u64, ElectricalComponentTelemetry>,
+    pub unhealthy_inverters: HashMap<u64, Option<ElectricalComponentTelemetry>>,
+}
+
+/// A tracker that watches every PV inverter in the pool and emits a
+/// [`PvPoolSnapshot`] whenever any inverter's telemetry or health
+/// classification changes.
+#[derive(Clone)]
+pub(crate) struct PvPoolTelemetryTracker {
+    component_ids: BTreeSet<u64>,
+    component_pool_status_tx: broadcast::Sender<PvPoolSnapshot>,
+    missing_data_tolerance: Duration,
+    healthy_state_codes: HashSet<ElectricalComponentStateCode>,
+    client: MicrogridClientHandle,
+}
+
+impl PvPoolTelemetryTracker {
+    pub(crate) fn new(
+        component_ids: BTreeSet<u64>,
+        missing_data_tolerance: Duration,
+        healthy_state_codes: HashSet<ElectricalComponentStateCode>,
+        client: MicrogridClientHandle,
+        component_pool_status_tx: broadcast::Sender<PvPoolSnapshot>,
+    ) -> Self {
+        Self {
+            component_ids,
+            component_pool_status_tx,
+            missing_data_tolerance,
+            healthy_state_codes,
+            client,
+        }
+    }
+
+    pub async fn run(self) -> Result<(), Error> {
+        if self.component_ids.is_empty() {
+            let e = "No component IDs provided for PvPoolTelemetryTracker".to_string();
+            tracing::error!("{}", e);
+            return Err(Error::component_data_error(e));
+        }
+
+        let mut healthy_inverters: HashMap<u64, ElectricalComponentTelemetry> = HashMap::new();
+        let mut unhealthy_inverters: HashMap<u64, Option<ElectricalComponentTelemetry>> =
+            HashMap::new();
+
+        let (status_tx, mut status_rx) = mpsc::channel(100);
+        for &inverter_id in &self.component_ids {
+            let component_data_stream = self
+                .client
+                .receive_electrical_component_telemetry_stream(inverter_id)
+                .await?;
+            let tracker = ComponentTelemetryTracker::new(
+                inverter_id,
+                self.missing_data_tolerance,
+                self.healthy_state_codes.clone(),
+                component_data_stream,
+                status_tx.clone(),
+            );
+            // Spawn a task for each component telemetry tracker.
+            tokio::spawn(async move {
+                tracker.run().await;
+            });
+            // Initially mark the inverter as unhealthy until we see data.
+            unhealthy_inverters.insert(inverter_id, None);
+        }
+
+        // Drop the original sender so the channel closes once every component
+        // tracker finishes, which signals the main loop to stop.
+        drop(status_tx);
+
+        let mut interval = tokio::time::interval(Duration::from_millis(200));
+        let mut last_sent: Option<PvPoolSnapshot> = None;
+
+        loop {
+            tokio::select! {
+                Some(status) = status_rx.recv() => {
+                    match status {
+                        ComponentHealthStatus::Healthy(id, data) => {
+                            healthy_inverters.insert(id, data);
+                            unhealthy_inverters.remove(&id);
+                        }
+                        ComponentHealthStatus::Unhealthy(id, data) => {
+                            unhealthy_inverters.insert(id, data);
+                            healthy_inverters.remove(&id);
+                        }
+                    }
+                },
+                _ = interval.tick() => {
+                    // Skip sending if the partitioning hasn't changed.
+                    let unchanged = last_sent.as_ref().is_some_and(|s| {
+                        s.healthy_inverters == healthy_inverters
+                            && s.unhealthy_inverters == unhealthy_inverters
+                    });
+                    if unchanged {
+                        continue;
+                    }
+                    let snapshot = PvPoolSnapshot {
+                        healthy_inverters: healthy_inverters.clone(),
+                        unhealthy_inverters: unhealthy_inverters.clone(),
+                    };
+                    if let Err(e) = self.component_pool_status_tx.send(snapshot.clone()) {
+                        tracing::error!("Failed to send PV pool snapshot: {}", e);
+                        break;
+                    }
+                    last_sent = Some(snapshot);
+                },
+                else => break,
+            }
+        }
+
+        let err = format!(
+            "PvPoolTelemetryTracker (component IDs {:?}) stopped receiving inverter telemetry updates.",
+            self.component_ids
+        );
+        tracing::error!("{}", err);
+        Err(Error::component_data_error(err))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeDelta;
+
+    use super::PvPoolSnapshot;
+    use crate::{
+        LogicalMeterConfig, LogicalMeterHandle, MicrogridClientHandle,
+        client::{
+            proto::common::microgrid::electrical_components::ElectricalComponentStateCode,
+            test_utils::{MockComponent, MockMicrogridApiClient},
+        },
+        microgrid::pv_pool::PvPool,
+    };
+
+    async fn new_pool(graph: MockComponent) -> PvPool {
+        let api = MockMicrogridApiClient::new(graph);
+        let client = MicrogridClientHandle::new_from_client(api);
+        let lm = LogicalMeterHandle::try_new(
+            client.clone(),
+            LogicalMeterConfig::new(TimeDelta::try_seconds(1).unwrap()),
+        )
+        .await
+        .unwrap();
+        PvPool::try_new(None, client, lm).unwrap()
+    }
+
+    /// Drains `rx` for up to `steps` * 100ms of simulated time, returning the
+    /// last snapshot seen.
+    async fn last_snapshot(
+        rx: &mut tokio::sync::broadcast::Receiver<PvPoolSnapshot>,
+        steps: u32,
+    ) -> PvPoolSnapshot {
+        let mut last = None;
+        for _ in 0..steps {
+            tokio::time::advance(std::time::Duration::from_millis(100)).await;
+            while let Ok(snap) = rx.try_recv() {
+                last = Some(snap);
+            }
+        }
+        last.expect("no snapshot received")
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn single_inverter_reaches_healthy_state() {
+        // grid → meter → pv_inverter(3)
+        let mut pool = new_pool(MockComponent::grid(1).with_children(vec![
+            MockComponent::meter(2).with_children(vec![
+                MockComponent::pv_inverter(3).with_power(vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+            ]),
+        ]))
+        .await;
+
+        let mut rx = pool.telemetry_snapshots();
+        let snap = last_snapshot(&mut rx, 10).await;
+
+        assert!(snap.healthy_inverters.contains_key(&3));
+        assert!(snap.unhealthy_inverters.is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn two_inverters_both_appear_in_snapshot() {
+        // grid → meter → [pv_inverter(3), pv_inverter(4)]
+        let mut pool = new_pool(MockComponent::grid(1).with_children(vec![
+            MockComponent::meter(2).with_children(vec![
+                MockComponent::pv_inverter(3).with_power(vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+                MockComponent::pv_inverter(4).with_power(vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+            ]),
+        ]))
+        .await;
+
+        let mut rx = pool.telemetry_snapshots();
+        let snap = last_snapshot(&mut rx, 10).await;
+
+        assert!(snap.healthy_inverters.contains_key(&3));
+        assert!(snap.healthy_inverters.contains_key(&4));
+        assert!(snap.unhealthy_inverters.is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn calling_telemetry_snapshots_twice_reuses_sender() {
+        let mut pool = new_pool(MockComponent::grid(1).with_children(vec![
+            MockComponent::meter(2).with_children(vec![
+                MockComponent::pv_inverter(3).with_power(vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+            ]),
+        ]))
+        .await;
+
+        let mut rx1 = pool.telemetry_snapshots();
+        let mut rx2 = pool.telemetry_snapshots();
+
+        // Advance so both receivers see at least one snapshot.
+        tokio::time::advance(std::time::Duration::from_millis(300)).await;
+
+        let snap1 = rx1.recv().await.unwrap();
+        let snap2 = rx2.recv().await.unwrap();
+        assert_eq!(
+            snap1, snap2,
+            "both subscriptions should observe the same snapshot"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn inverter_becomes_unhealthy_when_data_stops() {
+        // A handful of samples then silence; the stream stays open so the
+        // client actor doesn't reconnect and resupply data.
+        let mut pool = new_pool(MockComponent::grid(1).with_children(vec![
+            MockComponent::meter(2).with_children(vec![
+                MockComponent::pv_inverter(3)
+                    .with_power(vec![0.0, 0.0, 0.0])
+                    .with_silence_after_metrics(),
+            ]),
+        ]))
+        .await;
+
+        let mut rx = pool.telemetry_snapshots();
+
+        // First confirm the inverter reaches a healthy state.
+        let healthy = last_snapshot(&mut rx, 10).await;
+        assert!(
+            healthy.healthy_inverters.contains_key(&3),
+            "expected inverter to go healthy after initial samples, got {:?}",
+            healthy
+        );
+
+        // Advance well past the 10s missing-data tolerance — the component
+        // tracker should fire its interval and reclassify the inverter.
+        tokio::time::advance(std::time::Duration::from_secs(15)).await;
+        let unhealthy = last_snapshot(&mut rx, 5).await;
+
+        assert!(
+            unhealthy.healthy_inverters.is_empty(),
+            "inverter should be unhealthy after data stops, got healthy set {:?}",
+            unhealthy.healthy_inverters.keys()
+        );
+        assert!(unhealthy.unhealthy_inverters.contains_key(&3));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn inverter_with_bad_state_is_unhealthy() {
+        // Inverter reports an Error state — it must land in the unhealthy set
+        // even though samples keep arriving.
+        let mut pool = new_pool(MockComponent::grid(1).with_children(vec![
+            MockComponent::meter(2).with_children(vec![
+                MockComponent::pv_inverter(3)
+                    .with_power(vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+                    .with_state(ElectricalComponentStateCode::Error),
+            ]),
+        ]))
+        .await;
+
+        let mut rx = pool.telemetry_snapshots();
+        let snap = last_snapshot(&mut rx, 10).await;
+
+        assert!(
+            !snap.healthy_inverters.contains_key(&3),
+            "inverter with Error state should not be in healthy set"
+        );
+        assert!(
+            snap.unhealthy_inverters.contains_key(&3),
+            "inverter with Error state should be in unhealthy set, got {:?}",
+            snap
+        );
+    }
+}


### PR DESCRIPTION
The SDK exposed a `BatteryPool` but had no PV equivalent, and the per-inverter
health partition behind `power_bounds()` was crate-private. This PR adds a
`PvPool` mirroring `BatteryPool`, and makes the pool telemetry snapshots public
so a controller can distribute a pool-wide cap across only the healthy inverters.

## Changes

- New `PvPool`, reachable via `Microgrid::pv_pool(component_ids)`, with `power()`,
  `power_bounds()`, and `telemetry_snapshots()` — mirroring `BatteryPool`.
  Construction validates that every requested id is a PV inverter in the graph.
- Extract the parallel bounds-combination logic (`aggregate_parallel`) out of the
  battery bounds tracker into a shared `bounds_aggregation` module, reused by the
  new PV bounds tracker (no behaviour change).
- Make the pool telemetry trackers, their snapshot types (`BatteryPoolSnapshot`,
  `PvPoolSnapshot`, `InverterBatteryGroup{,Status}`), and
  `BatteryPool`/`PvPool::telemetry_snapshots()` public, re-exported from the crate root.