### PR TITLE
Fix telemetry and bounds tracker task leaks when consumers drop

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+- `BatteryPoolTelemetryTracker` and `PvPoolTelemetryTracker` are no longer public; they were an implementation detail. Use `BatteryPool::telemetry_snapshots()` / `PvPool::telemetry_snapshots()` to consume their snapshots.
 
 ## New Features
 
@@ -14,4 +14,6 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- The pool, group, and component telemetry trackers no longer leak their tasks (while logging at error level every tick) once their consumers are gone; normal shutdown is now logged at debug.
+
+- The client now evicts ended per-component telemetry streams from its cache, so a pool recreated on the same client receives telemetry again instead of silently getting none.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,12 +1,17 @@
 # Frequenz Microgrid Release Notes
 
+## Summary
+
+<!-- Here goes a general summary of what this release is about -->
+
+## Upgrading
+
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+
 ## New Features
 
-- New `PvPool` type (accessible via `Microgrid::pv_pool`) exposing:
-  - `power()` — a `Formula<Power>` for the pool's aggregated power.
-  - `power_bounds()` — a `broadcast::Receiver<Vec<Bounds<Power>>>` tracking the pool's power bounds.
-  - `telemetry_snapshots()` — a `broadcast::Receiver<PvPoolSnapshot>` partitioning the pool's inverters into healthy and unhealthy sets.
+<!-- Here goes the main new features and examples or instructions on how to use them -->
 
-- `BatteryPool::telemetry_snapshots()` exposes the same per-component health partition (`BatteryPoolSnapshot`).
+## Bug Fixes
 
-- The pool telemetry trackers and snapshot types (`BatteryPoolSnapshot`, `PvPoolSnapshot`, `InverterBatteryGroup`, `InverterBatteryGroupStatus`) are now public and re-exported from the crate root.
+<!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/src/client/microgrid_client_actor.rs
+++ b/src/client/microgrid_client_actor.rs
@@ -82,6 +82,29 @@ impl<T: MicrogridApiClient> MicrogridClientActor<T> {
                         }
                         Some(StreamStatus::Ended(component_id)) => {
                             components_to_retry.remove(&component_id);
+                            match component_streams.get(&component_id) {
+                                // A subscriber arrived between the stream
+                                // task's no-receivers check and this message;
+                                // the task is gone, so restart the stream for
+                                // the new subscriber.
+                                Some(tx) if tx.receiver_count() > 0 => {
+                                    let tx = tx.clone();
+                                    start_electrical_component_telemetry_stream(
+                                        &mut self.client,
+                                        component_id,
+                                        tx,
+                                        stream_status_tx.clone(),
+                                    )
+                                    .await;
+                                }
+                                // Drop the cached sender: nothing writes to it
+                                // anymore, so handing out further subscriptions
+                                // on it would never yield data. The next
+                                // subscription starts a fresh stream instead.
+                                _ => {
+                                    component_streams.remove(&component_id);
+                                }
+                            }
                         }
                         None => {
                             tracing::error!("MicrogridClientActor: Stream status channel closed, exiting.");

--- a/src/client/microgrid_client_handle.rs
+++ b/src/client/microgrid_client_handle.rs
@@ -405,4 +405,32 @@ mod tests {
             ]
         );
     }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_resubscribing_after_all_receivers_dropped_restarts_stream() {
+        let handle = new_client_handle();
+
+        let mut telemetry_rx = handle
+            .receive_electrical_component_telemetry_stream(2)
+            .await
+            .unwrap();
+        telemetry_rx.recv().await.unwrap();
+        drop(telemetry_rx);
+
+        // Let the stream task notice that all receivers are gone (it checks
+        // before each sample) and the actor process its Ended status, which
+        // must evict the cached sender.
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+        // A fresh subscription must get a live stream again, not a
+        // subscription on the dead cached channel.
+        let mut telemetry_rx = handle
+            .receive_electrical_component_telemetry_stream(2)
+            .await
+            .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(10), telemetry_rx.recv())
+            .await
+            .expect("no telemetry after resubscribing; stale stream cache?")
+            .unwrap();
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,8 @@ pub(crate) mod wall_clock_timer;
 
 mod microgrid;
 pub use microgrid::{
-    BatteryPool, BatteryPoolSnapshot, BatteryPoolTelemetryTracker, InverterBatteryGroup,
-    InverterBatteryGroupStatus, Microgrid, PvPool, PvPoolSnapshot, PvPoolTelemetryTracker,
+    BatteryPool, BatteryPoolSnapshot, InverterBatteryGroup, InverterBatteryGroupStatus, Microgrid,
+    PvPool, PvPoolSnapshot,
 };
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/src/microgrid.rs
+++ b/src/microgrid.rs
@@ -15,10 +15,10 @@ pub use pv_pool::PvPool;
 
 pub(crate) mod telemetry_tracker;
 pub use telemetry_tracker::battery_pool_telemetry_tracker::{
-    BatteryPoolSnapshot, BatteryPoolTelemetryTracker, InverterBatteryGroup,
+    BatteryPoolSnapshot, InverterBatteryGroup,
 };
 pub use telemetry_tracker::inverter_battery_group_telemetry_tracker::InverterBatteryGroupStatus;
-pub use telemetry_tracker::pv_pool_telemetry_tracker::{PvPoolSnapshot, PvPoolTelemetryTracker};
+pub use telemetry_tracker::pv_pool_telemetry_tracker::PvPoolSnapshot;
 
 use crate::{Error, LogicalMeterConfig, LogicalMeterHandle, MicrogridClientHandle};
 

--- a/src/microgrid/battery_bounds_tracker.rs
+++ b/src/microgrid/battery_bounds_tracker.rs
@@ -80,7 +80,9 @@ where
                     );
                 }
                 Err(broadcast::error::RecvError::Closed) => {
-                    tracing::error!(
+                    // The telemetry tracker upstream has shut down — a normal
+                    // teardown of the whole pool, not an error here.
+                    tracing::debug!(
                         "Pool status channel closed; {}/{} bounds tracker shutting down.",
                         InverterM::str_name(),
                         BatteryM::str_name(),

--- a/src/microgrid/pv_bounds_tracker.rs
+++ b/src/microgrid/pv_bounds_tracker.rs
@@ -65,7 +65,9 @@ where
                     );
                 }
                 Err(broadcast::error::RecvError::Closed) => {
-                    tracing::error!(
+                    // The telemetry tracker upstream has shut down — a normal
+                    // teardown of the whole pool, not an error here.
+                    tracing::debug!(
                         "Pool status channel closed; {} PV bounds tracker shutting down.",
                         M::str_name(),
                     );

--- a/src/microgrid/telemetry_tracker/battery_pool_telemetry_tracker.rs
+++ b/src/microgrid/telemetry_tracker/battery_pool_telemetry_tracker.rs
@@ -192,6 +192,13 @@ impl BatteryPoolTelemetryTracker {
                     }
                 },
                 _ = interval.tick() => {
+                    // The unchanged-skip below means a stable partition never
+                    // reaches `send()`, whose failure is otherwise the only
+                    // signal that every receiver has dropped. Check for that
+                    // here so the tracker still shuts down instead of leaking.
+                    if self.component_pool_status_tx.receiver_count() == 0 {
+                        break;
+                    }
                     if last_sent_status.as_ref() == Some(&inverter_battery_group_data) {
                         continue; // Skip sending if the status hasn't changed
                     }

--- a/src/microgrid/telemetry_tracker/battery_pool_telemetry_tracker.rs
+++ b/src/microgrid/telemetry_tracker/battery_pool_telemetry_tracker.rs
@@ -88,7 +88,11 @@ impl BatteryPoolTelemetryTracker {
 
         while let Some(battery_id) = unvisited_batteries.iter().next().cloned() {
             let group_inverters = graph
-                .predecessors(battery_id)?
+                .predecessors(battery_id)
+                .map_err(|e| {
+                    tracing::error!("Failed to query predecessors of battery {battery_id}: {e}");
+                    e
+                })?
                 .filter(|c| c.category() == crate::client::ElectricalComponentCategory::Inverter)
                 .map(|c| c.id)
                 .collect::<BTreeSet<_>>();
@@ -102,7 +106,13 @@ impl BatteryPoolTelemetryTracker {
             let mut group_batteries = BTreeSet::new();
             for inverter_id in &group_inverters {
                 let connected_batteries = graph
-                    .successors(*inverter_id)?
+                    .successors(*inverter_id)
+                    .map_err(|e| {
+                        tracing::error!(
+                            "Failed to query successors of inverter {inverter_id}: {e}"
+                        );
+                        e
+                    })?
                     .map(|c| c.id)
                     .collect::<BTreeSet<_>>();
 
@@ -129,7 +139,13 @@ impl BatteryPoolTelemetryTracker {
             // Ensure that group batteries are only connect to group inverters
             for battery_id in &group_batteries {
                 let connected_inverters = graph
-                    .predecessors(*battery_id)?
+                    .predecessors(*battery_id)
+                    .map_err(|e| {
+                        tracing::error!(
+                            "Failed to query predecessors of battery {battery_id}: {e}"
+                        );
+                        e
+                    })?
                     .filter(|c| {
                         c.category() == crate::client::ElectricalComponentCategory::Inverter
                     })
@@ -152,10 +168,13 @@ impl BatteryPoolTelemetryTracker {
         Ok(groups)
     }
 
-    pub async fn run(self) -> Result<(), Error> {
+    pub async fn run(self) {
         let mut inverter_battery_group_data = HashMap::new();
 
-        let inverter_battery_group_ids = self.get_inverter_battery_groups()?;
+        // Errors are logged at source inside `get_inverter_battery_groups`.
+        let Ok(inverter_battery_group_ids) = self.get_inverter_battery_groups() else {
+            return;
+        };
 
         let (component_status_tx, mut component_status_rx) = tokio::sync::mpsc::channel(100);
         for inverter_battery_group in inverter_battery_group_ids {
@@ -185,9 +204,10 @@ impl BatteryPoolTelemetryTracker {
                             inverter_battery_group_data.insert(group_ids, status);
                         }
                         // Every group tracker has exited and dropped its sender,
-                        // so no further updates will arrive. The `interval.tick()`
-                        // arm never disables, so the `select!` `else` can never
-                        // run; break here instead.
+                        // so no further updates will ever arrive. The `_ =
+                        // interval.tick()` arm below is a catch-all that never
+                        // disables, so the `select!` `else` branch can never run;
+                        // break here instead.
                         None => break,
                     }
                 },
@@ -202,11 +222,13 @@ impl BatteryPoolTelemetryTracker {
                     if last_sent_status.as_ref() == Some(&inverter_battery_group_data) {
                         continue; // Skip sending if the status hasn't changed
                     }
-                    if let Err(e) = self.component_pool_status_tx.send(
-                        BatteryPoolSnapshot(inverter_battery_group_data.clone())
-                    )
+                    if self
+                        .component_pool_status_tx
+                        .send(BatteryPoolSnapshot(inverter_battery_group_data.clone()))
+                        .is_err()
                     {
-                        tracing::error!("Failed to send pool snapshot: {}", e);
+                        // All receivers dropped between the check above and here;
+                        // a normal shutdown, recorded by the terminal log below.
                         break;
                     }
                     last_sent_status = Some(inverter_battery_group_data.clone());
@@ -214,14 +236,12 @@ impl BatteryPoolTelemetryTracker {
             }
         }
 
-        let err = format!(
-            "BatteryPoolTelemetryTracker (component IDs {:?}) stopped receiving group telemetry updates.",
+        // Reaching here means every group tracker exited or every receiver
+        // dropped — a normal shutdown, not an error.
+        tracing::debug!(
+            "BatteryPoolTelemetryTracker (component IDs {:?}) stopped: all group trackers or receivers are gone.",
             self.component_ids
         );
-
-        tracing::error!("{}", err);
-
-        Err(Error::component_data_error(err))
     }
 }
 

--- a/src/microgrid/telemetry_tracker/battery_pool_telemetry_tracker.rs
+++ b/src/microgrid/telemetry_tracker/battery_pool_telemetry_tracker.rs
@@ -47,7 +47,7 @@ impl BatteryPoolSnapshot {
 /// a [`BatteryPoolSnapshot`] whenever any component's telemetry or health
 /// classification changes.
 #[derive(Clone)]
-pub struct BatteryPoolTelemetryTracker {
+pub(crate) struct BatteryPoolTelemetryTracker {
     component_ids: BTreeSet<u64>,
     component_pool_status_tx: tokio::sync::broadcast::Sender<BatteryPoolSnapshot>,
     missing_data_tolerance: Duration,
@@ -168,7 +168,7 @@ impl BatteryPoolTelemetryTracker {
         Ok(groups)
     }
 
-    pub async fn run(self) {
+    pub(crate) async fn run(self) {
         let mut inverter_battery_group_data = HashMap::new();
 
         // Errors are logged at source inside `get_inverter_battery_groups`.

--- a/src/microgrid/telemetry_tracker/component_telemetry_tracker.rs
+++ b/src/microgrid/telemetry_tracker/component_telemetry_tracker.rs
@@ -79,14 +79,25 @@ impl ComponentTelemetryTracker {
                             // Reset the interval timer on receiving valid data
                             interval.reset();
                             let status = self.state_from_data(data);
-                            if let Err(e) = self.component_status_tx.send(status).await {
-                                tracing::error!("Failed to send component status: {}", e);
+                            if self.component_status_tx.send(status).await.is_err() {
+                                // The pool tracker dropped its receiver; there is
+                                // nothing left to report to, so stop tracking
+                                // instead of looping and logging forever.
+                                tracing::debug!(
+                                    "Component {} telemetry tracker stopping: pool tracker dropped its receiver.",
+                                    self.component_id
+                                );
+                                break;
                             }
                         }
                         Err(broadcast::error::RecvError::Lagged(_)) => {
                             continue;
                         }
                         Err(broadcast::error::RecvError::Closed) => {
+                            tracing::debug!(
+                                "Component {} telemetry tracker stopping: telemetry stream closed.",
+                                self.component_id
+                            );
                             drop(self.component_status_tx);
                             break;
                         }
@@ -95,8 +106,13 @@ impl ComponentTelemetryTracker {
                 _ = interval.tick() => {
                     // If we reach here, it means no data was received within the tolerance period
                     let status = ComponentHealthStatus::Unhealthy(self.component_id, None);
-                    if let Err(e) = self.component_status_tx.send(status).await {
-                        tracing::error!("Failed to send component status: {}", e);
+                    if self.component_status_tx.send(status).await.is_err() {
+                        // The pool tracker dropped its receiver; stop tracking.
+                        tracing::debug!(
+                            "Component {} telemetry tracker stopping: pool tracker dropped its receiver.",
+                            self.component_id
+                        );
+                        break;
                     }
                 }
             }

--- a/src/microgrid/telemetry_tracker/inverter_battery_group_telemetry_tracker.rs
+++ b/src/microgrid/telemetry_tracker/inverter_battery_group_telemetry_tracker.rs
@@ -15,7 +15,7 @@ use std::{
 use tokio::select;
 
 use crate::{
-    Error, MicrogridClientHandle,
+    MicrogridClientHandle,
     client::proto::common::microgrid::electrical_components::{
         ElectricalComponentStateCode, ElectricalComponentTelemetry,
     },
@@ -76,7 +76,7 @@ impl InverterBatteryGroupTelemetryTracker {
         }
     }
 
-    pub async fn run(self) -> Result<(), Error> {
+    pub async fn run(self) {
         let mut healthy_inverters = HashMap::new();
         let mut unhealthy_inverters = HashMap::new();
         let mut healthy_batteries = HashMap::new();
@@ -85,10 +85,19 @@ impl InverterBatteryGroupTelemetryTracker {
         let (inverter_status_tx, mut inverter_status_rx) = tokio::sync::mpsc::channel(100);
 
         for &inverter_id in &self.inverter_battery_group.inverter_ids {
-            let component_data_stream = self
+            let component_data_stream = match self
                 .client
                 .receive_electrical_component_telemetry_stream(inverter_id)
-                .await?;
+                .await
+            {
+                Ok(stream) => stream,
+                Err(e) => {
+                    tracing::error!(
+                        "Internal error opening telemetry stream for inverter {inverter_id}: {e}; inverter-battery group tracker aborting.",
+                    );
+                    return;
+                }
+            };
             let tracker = ComponentTelemetryTracker::new(
                 inverter_id,
                 self.missing_data_tolerance,
@@ -107,10 +116,19 @@ impl InverterBatteryGroupTelemetryTracker {
         let (battery_status_tx, mut battery_status_rx) = tokio::sync::mpsc::channel(100);
 
         for &battery_id in &self.inverter_battery_group.battery_ids {
-            let component_data_stream = self
+            let component_data_stream = match self
                 .client
                 .receive_electrical_component_telemetry_stream(battery_id)
-                .await?;
+                .await
+            {
+                Ok(stream) => stream,
+                Err(e) => {
+                    tracing::error!(
+                        "Internal error opening telemetry stream for battery {battery_id}: {e}; inverter-battery group tracker aborting.",
+                    );
+                    return;
+                }
+            };
             let tracker = ComponentTelemetryTracker::new(
                 battery_id,
                 self.missing_data_tolerance,
@@ -136,9 +154,13 @@ impl InverterBatteryGroupTelemetryTracker {
             select! {
                 inverter_status = inverter_status_rx.recv() => {
                     let Some(inverter_status) = inverter_status else {
-                        let e = String::from("Inverter telemetry tracker stopped receiving status updates.");
-                        tracing::error!("{}", e);
-                        return Err(Error::component_data_error(e));
+                        // Every inverter component tracker has exited and dropped
+                        // its sender — a normal shutdown, not an error.
+                        tracing::debug!(
+                            "Inverter-battery group tracker (inverters {:?}) stopping: all inverter component trackers have exited.",
+                            self.inverter_battery_group.inverter_ids
+                        );
+                        return;
                     };
                     match inverter_status {
                         ComponentHealthStatus::Healthy(component_id, data) => {
@@ -152,12 +174,14 @@ impl InverterBatteryGroupTelemetryTracker {
                     }
                 },
                 battery_status = battery_status_rx.recv() => {
-                    let Some(battery_status) =  battery_status  else {
-                        let e = String::from(
-                            "Battery telemetry tracker stopped receiving status updates."
+                    let Some(battery_status) = battery_status else {
+                        // Every battery component tracker has exited and dropped
+                        // its sender — a normal shutdown, not an error.
+                        tracing::debug!(
+                            "Inverter-battery group tracker (batteries {:?}) stopping: all battery component trackers have exited.",
+                            self.inverter_battery_group.battery_ids
                         );
-                        tracing::error!("{}", e);
-                        return Err(Error::component_data_error(e));
+                        return;
                     };
                     match battery_status {
                         ComponentHealthStatus::Healthy(component_id, data) => {
@@ -171,7 +195,7 @@ impl InverterBatteryGroupTelemetryTracker {
                     }
                 }
             }
-            if let Err(e) = self
+            if self
                 .status_tx
                 .send((
                     self.inverter_battery_group.clone(),
@@ -183,12 +207,14 @@ impl InverterBatteryGroupTelemetryTracker {
                     },
                 ))
                 .await
+                .is_err()
             {
-                tracing::error!("Failed to send inverter-battery group status: {}", e);
-                return Err(Error::component_data_error(format!(
-                    "Failed to send inverter-battery group status: {}",
-                    e
-                )));
+                // The pool tracker dropped its receiver — a normal shutdown.
+                tracing::debug!(
+                    "Inverter-battery group tracker {:?} stopping: the pool tracker dropped its receiver.",
+                    self.inverter_battery_group
+                );
+                return;
             }
         }
     }

--- a/src/microgrid/telemetry_tracker/pv_pool_telemetry_tracker.rs
+++ b/src/microgrid/telemetry_tracker/pv_pool_telemetry_tracker.rs
@@ -41,7 +41,7 @@ pub struct PvPoolSnapshot {
 /// [`PvPoolSnapshot`] whenever any inverter's telemetry or health
 /// classification changes.
 #[derive(Clone)]
-pub struct PvPoolTelemetryTracker {
+pub(crate) struct PvPoolTelemetryTracker {
     component_ids: BTreeSet<u64>,
     component_pool_status_tx: broadcast::Sender<PvPoolSnapshot>,
     missing_data_tolerance: Duration,
@@ -66,7 +66,7 @@ impl PvPoolTelemetryTracker {
         }
     }
 
-    pub async fn run(self) {
+    pub(crate) async fn run(self) {
         if self.component_ids.is_empty() {
             tracing::error!("No component IDs provided for PvPoolTelemetryTracker");
             return;

--- a/src/microgrid/telemetry_tracker/pv_pool_telemetry_tracker.rs
+++ b/src/microgrid/telemetry_tracker/pv_pool_telemetry_tracker.rs
@@ -125,6 +125,13 @@ impl PvPoolTelemetryTracker {
                     }
                 },
                 _ = interval.tick() => {
+                    // The unchanged-skip below means a stable partition never
+                    // reaches `send()`, whose failure is otherwise the only
+                    // signal that every receiver has dropped. Check for that
+                    // here so the tracker still shuts down instead of leaking.
+                    if self.component_pool_status_tx.receiver_count() == 0 {
+                        break;
+                    }
                     // Skip sending if the partitioning hasn't changed.
                     let unchanged = last_sent.as_ref().is_some_and(|s| {
                         s.healthy_inverters == healthy_inverters

--- a/src/microgrid/telemetry_tracker/pv_pool_telemetry_tracker.rs
+++ b/src/microgrid/telemetry_tracker/pv_pool_telemetry_tracker.rs
@@ -15,7 +15,7 @@ use std::{
 use tokio::sync::{broadcast, mpsc};
 
 use crate::{
-    Error, MicrogridClientHandle,
+    MicrogridClientHandle,
     client::proto::common::microgrid::electrical_components::{
         ElectricalComponentStateCode, ElectricalComponentTelemetry,
     },
@@ -66,11 +66,10 @@ impl PvPoolTelemetryTracker {
         }
     }
 
-    pub async fn run(self) -> Result<(), Error> {
+    pub async fn run(self) {
         if self.component_ids.is_empty() {
-            let e = "No component IDs provided for PvPoolTelemetryTracker".to_string();
-            tracing::error!("{}", e);
-            return Err(Error::component_data_error(e));
+            tracing::error!("No component IDs provided for PvPoolTelemetryTracker");
+            return;
         }
 
         let mut healthy_inverters: HashMap<u64, ElectricalComponentTelemetry> = HashMap::new();
@@ -79,10 +78,19 @@ impl PvPoolTelemetryTracker {
 
         let (status_tx, mut status_rx) = mpsc::channel(100);
         for &inverter_id in &self.component_ids {
-            let component_data_stream = self
+            let component_data_stream = match self
                 .client
                 .receive_electrical_component_telemetry_stream(inverter_id)
-                .await?;
+                .await
+            {
+                Ok(stream) => stream,
+                Err(e) => {
+                    tracing::error!(
+                        "Internal error opening telemetry stream for inverter {inverter_id}: {e}; PV pool telemetry tracker aborting.",
+                    );
+                    return;
+                }
+            };
             let tracker = ComponentTelemetryTracker::new(
                 inverter_id,
                 self.missing_data_tolerance,
@@ -118,9 +126,10 @@ impl PvPoolTelemetryTracker {
                             healthy_inverters.remove(&id);
                         }
                         // Every component tracker has exited and dropped its
-                        // sender, so no further updates will arrive. The
-                        // `interval.tick()` arm never disables, so the `select!`
-                        // `else` can never run; break here instead.
+                        // sender, so no further updates will ever arrive. The
+                        // `_ = interval.tick()` arm below is a catch-all that
+                        // never disables, so the `select!` `else` branch can
+                        // never run; break here instead.
                         None => break,
                     }
                 },
@@ -144,8 +153,9 @@ impl PvPoolTelemetryTracker {
                         healthy_inverters: healthy_inverters.clone(),
                         unhealthy_inverters: unhealthy_inverters.clone(),
                     };
-                    if let Err(e) = self.component_pool_status_tx.send(snapshot.clone()) {
-                        tracing::error!("Failed to send PV pool snapshot: {}", e);
+                    if self.component_pool_status_tx.send(snapshot.clone()).is_err() {
+                        // All receivers dropped between the check above and here;
+                        // a normal shutdown, recorded by the terminal log below.
                         break;
                     }
                     last_sent = Some(snapshot);
@@ -153,12 +163,12 @@ impl PvPoolTelemetryTracker {
             }
         }
 
-        let err = format!(
-            "PvPoolTelemetryTracker (component IDs {:?}) stopped receiving inverter telemetry updates.",
+        // Reaching here means every component tracker exited or every receiver
+        // dropped — a normal shutdown, not an error.
+        tracing::debug!(
+            "PvPoolTelemetryTracker (component IDs {:?}) stopped: all component trackers or receivers are gone.",
             self.component_ids
         );
-        tracing::error!("{}", err);
-        Err(Error::component_data_error(err))
     }
 }
 


### PR DESCRIPTION
Telemetry and bounds trackers leaked their tasks — logging at error level on every tick — once all their consumers had dropped, and a pool recreated on the same client silently received no telemetry because the client actor kept a dead stream sender cached. This branch shuts the trackers down cleanly when their consumers are gone and evicts ended streams from the client cache.

## Changes

- Pool, group, and component telemetry trackers and the PV/battery bounds trackers now shut down (logged at debug) when all their receivers/consumers have dropped, instead of leaking the task and logging an error every tick.
- Pool telemetry trackers check `receiver_count()` each tick, covering the unchanged-partition skip path where a failed `send()` would otherwise never fire to signal that the last receiver is gone.
- The client actor evicts an ended per-component telemetry stream from its cache, so a pool recreated on the same client starts a fresh stream and receives telemetry again — restarting the stream in place if a subscriber raced in before the eviction.
- The tracker `run()` loops no longer return `Result` (shutdown is not an error); the remaining startup failures now log at their source before the task exits instead of being propagated into a discarded `JoinHandle`.