### PR TITLE
Fix streaming of the AcFrequency metric

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frequenz-microgrid"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "A high-level interface to the Frequenz Microgrid API."
 repository = "https://github.com/frequenz-floss/frequenz-microgrid-rs"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,12 +1,5 @@
 # Frequenz Microgrid Release Notes
 
-## New Features
+## Bug Fixes
 
-- New `PvPool` type (accessible via `Microgrid::pv_pool`) exposing:
-  - `power()` — a `Formula<Power>` for the pool's aggregated power.
-  - `power_bounds()` — a `broadcast::Receiver<Vec<Bounds<Power>>>` tracking the pool's power bounds.
-  - `telemetry_snapshots()` — a `broadcast::Receiver<PvPoolSnapshot>` partitioning the pool's inverters into healthy and unhealthy sets.
-
-- `BatteryPool::telemetry_snapshots()` exposes the same per-component health partition (`BatteryPoolSnapshot`).
-
-- The pool telemetry trackers and snapshot types (`BatteryPoolSnapshot`, `PvPoolSnapshot`, `InverterBatteryGroup`, `InverterBatteryGroupStatus`) are now public and re-exported from the crate root.
+- Fixed streaming of the `AcFrequency` metric (e.g. `Microgrid`'s grid frequency). Subscribing to a `Frequency` formula previously failed because the logical meter actor didn't route the `Frequency` quantity.

--- a/src/client/test_utils.rs
+++ b/src/client/test_utils.rs
@@ -37,7 +37,7 @@ use crate::{
             ReceiveElectricalComponentTelemetryStreamResponse,
         },
     },
-    quantity::{Current, Power, ReactivePower, Voltage},
+    quantity::{Current, Frequency, Power, ReactivePower, Voltage},
 };
 
 /// A mock implementation of the `MicrogridApiClient` trait for testing purposes.
@@ -70,6 +70,9 @@ pub struct MockComponent {
     pub component: ElectricalComponent,
     pub children: Vec<MockComponent>,
     pub metrics: Vec<MockMetricRow>,
+    /// AC frequency samples, one entry per telemetry frame (parallel to
+    /// `metrics`). Set via [`MockComponent::with_frequency`].
+    frequency: Vec<Option<Frequency>>,
     /// Overrides the state code reported in each telemetry sample. `None`
     /// defaults to `Ready`.
     state_code: Option<ElectricalComponentStateCode>,
@@ -255,6 +258,20 @@ impl MockComponent {
         self
     }
 
+    pub fn with_frequency(mut self, frequency: Vec<f32>) -> Self {
+        // Extend `metrics` so every frequency frame is still emitted even when
+        // no other metric is set for it (frequency lives in a parallel array).
+        if frequency.len() > self.metrics.len() {
+            self.metrics
+                .resize(frequency.len(), (None, None, None, None));
+        }
+        self.frequency = frequency
+            .iter()
+            .map(|f| Some(Frequency::from_hertz(*f)))
+            .collect();
+        self
+    }
+
     /// Overrides the state code reported in each telemetry sample.
     pub fn with_state(mut self, code: ElectricalComponentStateCode) -> Self {
         self.state_code = Some(code);
@@ -389,6 +406,7 @@ impl MicrogridApiClient for MockMicrogridApiClient {
             && !component.metrics.is_empty()
         {
             let metrics = component.metrics.clone();
+            let frequency = component.frequency.clone();
             let state_code = component
                 .state_code
                 .unwrap_or(ElectricalComponentStateCode::Ready);
@@ -399,7 +417,7 @@ impl MicrogridApiClient for MockMicrogridApiClient {
                 let mut interval = tokio::time::interval(dur);
                 let offset = chrono::TimeDelta::from_std(dur).unwrap_or_default();
 
-                for metrics in metrics.iter() {
+                for (frame, metrics) in metrics.iter().enumerate() {
                     interval.tick().await;
                     // `tokio::time::interval`'s first tick fires
                     // immediately, so `clock.wall_now()` is still the
@@ -480,6 +498,23 @@ impl MicrogridApiClient for MockMicrogridApiClient {
                                     metric_value_variant::MetricValueVariant::SimpleMetric(
                                         SimpleMetricValue {
                                             value: current.as_amperes(),
+                                        },
+                                    ),
+                                ),
+                            }),
+                            bounds: vec![],
+                            connection: None,
+                        });
+                    }
+                    if let Some(Some(frequency)) = frequency.get(frame) {
+                        metric_samples.push(MetricSample {
+                            sample_time: ts,
+                            metric: Metric::AcFrequency as i32,
+                            value: Some(MetricValueVariant {
+                                metric_value_variant: Some(
+                                    metric_value_variant::MetricValueVariant::SimpleMetric(
+                                        SimpleMetricValue {
+                                            value: frequency.as_hertz(),
                                         },
                                     ),
                                 ),

--- a/src/logical_meter/logical_meter_actor.rs
+++ b/src/logical_meter/logical_meter_actor.rs
@@ -13,7 +13,7 @@ use tokio::sync::{broadcast, mpsc, oneshot};
 
 use crate::ErrorKind;
 use crate::client::proto::common::metrics::{Metric, metric_value_variant::MetricValueVariant};
-use crate::quantity::{Current, Power, Quantity, ReactivePower, Voltage};
+use crate::quantity::{Current, Frequency, Power, Quantity, ReactivePower, Voltage};
 use crate::wall_clock_timer::{Clock, WallClockTimer};
 use crate::{
     Error, MicrogridClientHandle, Sample,
@@ -75,6 +75,7 @@ pub(crate) enum TypedFormulaResponseSender {
     Voltage(FormulaStreamSender<Voltage>),
     ReactivePower(FormulaStreamSender<ReactivePower>),
     Current(FormulaStreamSender<Current>),
+    Frequency(FormulaStreamSender<Frequency>),
 }
 
 impl<Q: Quantity + 'static> TryFrom<FormulaStreamSender<Q>> for TypedFormulaResponseSender {
@@ -95,8 +96,12 @@ impl<Q: Quantity + 'static> TryFrom<FormulaStreamSender<Q>> for TypedFormulaResp
             Ok(sender) => return Ok(TypedFormulaResponseSender::ReactivePower(*sender)),
             Err(sender) => sender,
         };
-        match sender.downcast::<FormulaStreamSender<Current>>() {
-            Ok(sender) => Ok(TypedFormulaResponseSender::Current(*sender)),
+        let sender = match sender.downcast::<FormulaStreamSender<Current>>() {
+            Ok(sender) => return Ok(TypedFormulaResponseSender::Current(*sender)),
+            Err(sender) => sender,
+        };
+        match sender.downcast::<FormulaStreamSender<Frequency>>() {
+            Ok(sender) => Ok(TypedFormulaResponseSender::Frequency(*sender)),
             _ => Err(Error::internal(format!(
                 "Can't create TypedFormulaResponseSender for `{}`",
                 std::any::type_name::<Q>()
@@ -128,6 +133,7 @@ struct Formulas {
     voltage: HashMap<(String, Metric), LogicalMeterFormula<Voltage>>,
     reactive_power: HashMap<(String, Metric), LogicalMeterFormula<ReactivePower>>,
     current: HashMap<(String, Metric), LogicalMeterFormula<Current>>,
+    frequency: HashMap<(String, Metric), LogicalMeterFormula<Frequency>>,
 }
 
 impl Formulas {
@@ -137,6 +143,7 @@ impl Formulas {
             || self.voltage.contains_key(key)
             || self.reactive_power.contains_key(key)
             || self.current.contains_key(key)
+            || self.frequency.contains_key(key)
     }
 
     /// Forwards a fresh subscription receiver for an existing formula.
@@ -155,6 +162,9 @@ impl Formulas {
                 Self::try_subscribe(&self.reactive_power, key, tx)
             }
             TypedFormulaResponseSender::Current(tx) => Self::try_subscribe(&self.current, key, tx),
+            TypedFormulaResponseSender::Frequency(tx) => {
+                Self::try_subscribe(&self.frequency, key, tx)
+            }
         }?;
         if !found {
             // The caller checked `contains_key` across all quantities before
@@ -214,6 +224,9 @@ impl Formulas {
             TypedFormulaResponseSender::Current(tx) => {
                 Self::insert_and_send(&mut self.current, formula_key, formula_engine, tx)?;
             }
+            TypedFormulaResponseSender::Frequency(tx) => {
+                Self::insert_and_send(&mut self.frequency, formula_key, formula_engine, tx)?;
+            }
         }
 
         Ok(components)
@@ -242,6 +255,7 @@ impl Formulas {
         Self::collect_keys(&self.voltage, &mut keys);
         Self::collect_keys(&self.reactive_power, &mut keys);
         Self::collect_keys(&self.current, &mut keys);
+        Self::collect_keys(&self.frequency, &mut keys);
         keys
     }
 
@@ -344,6 +358,9 @@ impl<C: Clock> LogicalMeterActor<C> {
                             &mut resampled,
                             &mut formulas.reactive_power,
                             ReactivePower::from_volt_amperes_reactive
+                        ).err())
+                        .or(self.evaluate_formulas(
+                            &mut resampled, &mut formulas.frequency, Frequency::from_hertz
                         ).err())
                     } {
                         if err.kind() == ErrorKind::DroppedUnusedFormulas {
@@ -636,7 +653,7 @@ mod tests {
         LogicalMeterConfig, LogicalMeterHandle, MicrogridClientHandle,
         client::test_utils::{MockComponent, MockMicrogridApiClient, TokioSyncedClock},
         logical_meter::formula::Formula,
-        quantity::Power,
+        quantity::{Frequency, Power},
     };
 
     async fn new_handle(
@@ -770,6 +787,33 @@ mod tests {
             TimeDelta::try_seconds(1).unwrap(),
         );
         assert!(first.value().is_some());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_actor_emits_samples_for_subscribed_frequency_formula() {
+        let meter = MockComponent::meter(2)
+            .with_frequency(vec![50.0, 50.1, 49.9, 50.0, 50.2, 49.8, 50.0, 50.1]);
+        let lm = new_handle(
+            meter,
+            LogicalMeterConfig::new(TimeDelta::try_seconds(1).unwrap()),
+            aligned_clock(),
+        )
+        .await;
+        let formula: Formula<Frequency> = lm.grid::<crate::metric::AcFrequency>().unwrap();
+        let rx = formula.subscribe().await.unwrap();
+        let mut stream = BroadcastStream::new(rx);
+
+        let first = loop {
+            match tokio::time::timeout(std::time::Duration::from_secs(10), stream.next()).await {
+                Ok(Some(Ok(s))) => break s,
+                Ok(Some(Err(_))) => continue,
+                _ => panic!("no first frequency sample"),
+            }
+        };
+        assert!(
+            first.value().is_some(),
+            "expected a frequency value to be streamed for the grid",
+        );
     }
 
     #[tokio::test(start_paused = true)]


### PR DESCRIPTION
The logical meter actor never routed the `Frequency` quantity, so subscribing to an `AcFrequency` formula (e.g. `Microgrid`'s grid frequency) failed the downcast in `TypedFormulaResponseSender` and returned an internal error. This wires `Frequency` through the actor so `AcFrequency` streams like every other metric.

## Changes

- Add the `Frequency` quantity to the logical meter actor's typed formula sender, formula maps, subscription dispatch, resampler-key collection, and per-tick formula evaluation.
- Extend the mock API client with a `with_frequency` builder that emits `AcFrequency` telemetry, keeping the public `MockMetricRow` tuple unchanged (frequency rides in a parallel array).
- Add a grid-frequency streaming test.
- Bump version to 0.5.1 and update release notes.
