### PR TITLE
Pass component operational modes to the component graph

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/lib.rs"
 [dependencies]
 async-trait = "0.1.89"
 chrono = "0.4"
-frequenz-microgrid-component-graph = "0.6.0"
+frequenz-microgrid-component-graph = "0.6.2"
 frequenz-microgrid-formula-engine = "0.1.0"
 frequenz-resampling = "0.2"
 futures = "0.3.31"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,11 +6,14 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+- The bundled Microgrid API protos moved to `frequenz-api-microgrid` v0.19.0 (`frequenz-api-common` v0.8.4). The re-exported `client::ElectricalComponentCategory` gained the `SteamBoiler` variant; an exhaustive `match` on it needs a new arm.
+- `client::ElectricalComponent` gained the fields `operational_mode` and `model` (`manufacturer` and `model_name` are deprecated in favour of `model`); struct literals need `..Default::default()`.
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+- Component operational modes are passed to the component graph. Formulas no longer read components whose mode is `Inactive` or `ControlOnly`; for such a component, `LogicalMeterHandle::component()` returns a formula with no reading.
+- The crate now requires `frequenz-microgrid-component-graph` 0.6.2 (was 0.6.0), which brings the operational-mode support and formula fixes; see its release notes.
+- `test-utils`: `MockComponent::with_operational_mode()` sets a mock component's operational mode.
 
 ## Bug Fixes
 

--- a/src/client/proto/graph.rs
+++ b/src/client/proto/graph.rs
@@ -124,6 +124,32 @@ impl frequenz_microgrid_component_graph::Node
             pb::ElectricalComponentCategory::SteamBoiler => gr::ComponentCategory::SteamBoiler,
         }
     }
+
+    fn operational_mode(&self) -> frequenz_microgrid_component_graph::OperationalMode {
+        use super::common::microgrid::electrical_components as pb;
+        use frequenz_microgrid_component_graph as gr;
+
+        let mode = pb::ElectricalComponentOperationalMode::try_from(self.operational_mode)
+            .unwrap_or_else(|e| {
+                error!(
+                    "Error converting operational mode of component {}: {}",
+                    self.id, e
+                );
+                pb::ElectricalComponentOperationalMode::Unspecified
+            });
+
+        match mode {
+            pb::ElectricalComponentOperationalMode::Unspecified => gr::OperationalMode::Unspecified,
+            pb::ElectricalComponentOperationalMode::Inactive => gr::OperationalMode::Inactive,
+            pb::ElectricalComponentOperationalMode::TelemetryOnly => {
+                gr::OperationalMode::TelemetryOnly
+            }
+            pb::ElectricalComponentOperationalMode::ControlOnly => gr::OperationalMode::ControlOnly,
+            pb::ElectricalComponentOperationalMode::ControlAndTelemetry => {
+                gr::OperationalMode::ControlAndTelemetry
+            }
+        }
+    }
 }
 
 impl frequenz_microgrid_component_graph::Edge
@@ -152,6 +178,56 @@ mod tests {
         assert_eq!(
             gr::Node::category(&component),
             gr::ComponentCategory::SteamBoiler
+        );
+    }
+
+    #[test]
+    fn operational_modes_map_to_the_graph_modes() {
+        let cases = [
+            (
+                pb::ElectricalComponentOperationalMode::Unspecified,
+                gr::OperationalMode::Unspecified,
+            ),
+            (
+                pb::ElectricalComponentOperationalMode::Inactive,
+                gr::OperationalMode::Inactive,
+            ),
+            (
+                pb::ElectricalComponentOperationalMode::TelemetryOnly,
+                gr::OperationalMode::TelemetryOnly,
+            ),
+            (
+                pb::ElectricalComponentOperationalMode::ControlOnly,
+                gr::OperationalMode::ControlOnly,
+            ),
+            (
+                pb::ElectricalComponentOperationalMode::ControlAndTelemetry,
+                gr::OperationalMode::ControlAndTelemetry,
+            ),
+        ];
+
+        for (mode, expected) in cases {
+            let component = pb::ElectricalComponent {
+                operational_mode: mode as i32,
+                ..Default::default()
+            };
+            assert_eq!(
+                gr::Node::operational_mode(&component),
+                expected,
+                "unexpected mapping for {mode:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_operational_mode_maps_to_unspecified() {
+        let component = pb::ElectricalComponent {
+            operational_mode: 99,
+            ..Default::default()
+        };
+        assert_eq!(
+            gr::Node::operational_mode(&component),
+            gr::OperationalMode::Unspecified
         );
     }
 }

--- a/src/client/proto/graph.rs
+++ b/src/client/proto/graph.rs
@@ -121,6 +121,7 @@ impl frequenz_microgrid_component_graph::Node
             }
             pb::ElectricalComponentCategory::CapacitorBank => gr::ComponentCategory::CapacitorBank,
             pb::ElectricalComponentCategory::WindTurbine => gr::ComponentCategory::WindTurbine,
+            pb::ElectricalComponentCategory::SteamBoiler => gr::ComponentCategory::SteamBoiler,
         }
     }
 }
@@ -134,5 +135,23 @@ impl frequenz_microgrid_component_graph::Edge
 
     fn destination(&self) -> u64 {
         self.destination_electrical_component_id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::common::microgrid::electrical_components as pb;
+    use frequenz_microgrid_component_graph as gr;
+
+    #[test]
+    fn steam_boiler_category_maps_to_the_graph_category() {
+        let component = pb::ElectricalComponent {
+            category: pb::ElectricalComponentCategory::SteamBoiler as i32,
+            ..Default::default()
+        };
+        assert_eq!(
+            gr::Node::category(&component),
+            gr::ComponentCategory::SteamBoiler
+        );
     }
 }

--- a/src/client/test_utils.rs
+++ b/src/client/test_utils.rs
@@ -23,8 +23,9 @@ use crate::{
             microgrid::electrical_components::{
                 ElectricalComponent, ElectricalComponentCategory,
                 ElectricalComponentCategorySpecificInfo, ElectricalComponentConnection,
-                ElectricalComponentStateCode, ElectricalComponentStateSnapshot,
-                ElectricalComponentTelemetry, Inverter, InverterType, MetricConfigBounds,
+                ElectricalComponentOperationalMode, ElectricalComponentStateCode,
+                ElectricalComponentStateSnapshot, ElectricalComponentTelemetry, Inverter,
+                InverterType, MetricConfigBounds,
                 electrical_component_category_specific_info::Kind,
             },
         },
@@ -275,6 +276,12 @@ impl MockComponent {
     /// Overrides the state code reported in each telemetry sample.
     pub fn with_state(mut self, code: ElectricalComponentStateCode) -> Self {
         self.state_code = Some(code);
+        self
+    }
+
+    /// Sets the component's operational mode.
+    pub fn with_operational_mode(mut self, mode: ElectricalComponentOperationalMode) -> Self {
+        self.component.operational_mode = mode as i32;
         self
     }
 

--- a/src/logical_meter/logical_meter_handle.rs
+++ b/src/logical_meter/logical_meter_handle.rs
@@ -161,6 +161,9 @@ impl LogicalMeterHandle {
 
     /// Returns a receiver that streams samples for the given `metric` for the
     /// given component ID.
+    ///
+    /// For a component whose operational mode provides no telemetry
+    /// (`Inactive` or `ControlOnly`), the formula has no reading.
     pub fn component<M: metric::Metric>(
         &self,
         component_id: u64,

--- a/src/logical_meter/logical_meter_handle.rs
+++ b/src/logical_meter/logical_meter_handle.rs
@@ -210,6 +210,7 @@ mod tests {
 
     use crate::{
         LogicalMeterConfig, LogicalMeterHandle, MicrogridClientHandle, Sample,
+        client::proto::common::microgrid::electrical_components::ElectricalComponentOperationalMode,
         client::test_utils::{
             MockComponent,
             MockMicrogridApiClient, //
@@ -590,6 +591,82 @@ mod tests {
                 Some(14.75),
             ],
         )
+    }
+
+    /// `grid(1) -> meter(2) -> [meter(3) -> [pv_inverter(4), pv_inverter(5)]]`,
+    /// with `mode`, when set, applied to inverter 4.
+    fn pv_topology(mode: Option<ElectricalComponentOperationalMode>) -> MockComponent {
+        let mut inverter_4 = MockComponent::pv_inverter(4);
+        if let Some(mode) = mode {
+            inverter_4 = inverter_4.with_operational_mode(mode);
+        }
+        MockComponent::grid(1).with_children(vec![MockComponent::meter(2).with_children(vec![
+            MockComponent::meter(3).with_children(vec![inverter_4, MockComponent::pv_inverter(5)]),
+        ])])
+    }
+
+    /// Builds a logical-meter handle over [`pv_topology`] with the given
+    /// operational mode on inverter 4.
+    async fn pv_handle(mode: Option<ElectricalComponentOperationalMode>) -> LogicalMeterHandle {
+        crate::microgrid::test_utils::handles(pv_topology(mode))
+            .await
+            .1
+    }
+
+    #[tokio::test]
+    async fn test_non_telemetry_modes_are_not_measurement_sources() {
+        for mode in [
+            ElectricalComponentOperationalMode::Inactive,
+            ElectricalComponentOperationalMode::ControlOnly,
+        ] {
+            let lm = pv_handle(Some(mode)).await;
+
+            // The inactive inverter has no reading, so no child sum is exact;
+            // the graph keeps the meter as primary source and the remaining
+            // inverter as best-effort fallback.
+            assert_eq!(
+                lm.pv::<crate::metric::AcPowerActive>(None)
+                    .unwrap()
+                    .to_string(),
+                "METRIC_AC_POWER_ACTIVE::(COALESCE(#3, #5, 0.0))",
+                "{mode:?}"
+            );
+
+            assert_eq!(
+                lm.component::<crate::metric::AcPowerActive>(4)
+                    .unwrap()
+                    .to_string(),
+                "METRIC_AC_POWER_ACTIVE::(None)",
+                "{mode:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_telemetry_providing_modes_keep_the_formula() {
+        let baseline = pv_handle(None)
+            .await
+            .pv::<crate::metric::AcPowerActive>(None)
+            .unwrap()
+            .to_string();
+        assert!(baseline.contains("#4"), "{baseline}");
+
+        for mode in [
+            // Explicit Unspecified equals the unset field (prost default 0).
+            ElectricalComponentOperationalMode::Unspecified,
+            ElectricalComponentOperationalMode::TelemetryOnly,
+            ElectricalComponentOperationalMode::ControlAndTelemetry,
+        ] {
+            assert_eq!(
+                pv_handle(Some(mode))
+                    .await
+                    .pv::<crate::metric::AcPowerActive>(None)
+                    .unwrap()
+                    .to_string(),
+                baseline,
+                "{mode:?}"
+            );
+        }
     }
 
     async fn fetch_samples<Q: Quantity>(formula: Formula<Q>, num_values: usize) -> Vec<Sample<Q>> {

--- a/src/microgrid.rs
+++ b/src/microgrid.rs
@@ -10,7 +10,7 @@ mod pool_bounds_tracker;
 mod pool_validation;
 
 #[cfg(test)]
-mod test_utils;
+pub(crate) mod test_utils;
 
 mod battery_pool;
 pub use battery_pool::BatteryPool;

--- a/src/microgrid/test_utils.rs
+++ b/src/microgrid/test_utils.rs
@@ -1,7 +1,7 @@
 // License: MIT
 // Copyright © 2026 Frequenz Energy-as-a-Service GmbH
 
-//! Shared test helpers for the pool modules.
+//! Shared test helpers for the pool and logical-meter tests.
 
 use chrono::TimeDelta;
 


### PR DESCRIPTION
`frequenz-microgrid-component-graph` 0.6.2 leaves components that provide no
telemetry out of its formulas, but only if the `Node` reports their operational
mode — which this crate's `Node` impl could not, because the pinned protos
predate the field. Bump the proto submodule to v0.19.0 (`frequenz-api-common`
v0.8.4) and map the mode through.

## Changes

- Submodule v0.18.0 → v0.19.0: the `v1alpha18` tree `build.rs` compiles is
  byte-identical; the change is the nested `frequenz-api-common` v0.8.0 → v0.8.4
  (`operational_mode` — v0.8.4 rather than v0.8.3 because 0.8.3 spells the enum
  value `TELEMTRY_ONLY`). The `SteamBoiler` category arrives with it and is
  mapped in the same commit, since the exhaustive match requires it.
- `Node::operational_mode()` in `src/client/proto/graph.rs`, the graph crate's
  reference mapping; unknown values fall back to `Unspecified` like `category()`.
- Tests: `test_non_telemetry_modes_are_not_measurement_sources` pins
  `COALESCE(#3, #5, 0.0)` for a PV pair with one `Inactive`/`ControlOnly`
  inverter — the meter stays primary because no child sum is exact once a
  child has no reading (the graph's `stands_alone` rule), not because of a
  meter preference. `component()` for such a component renders `None`.
- Wire-compatible with older servers: an unset field decodes as `Unspecified`,
  which provides telemetry, so formulas are unchanged against them.
- Left alone on purpose: pools still discover components by category only, so
  an `Inactive` component appears in a pool as unhealthy — follow-up if wanted.

## Breaking

- Source-level only: `ElectricalComponentCategory` (re-exported) gains
  `SteamBoiler`; `ElectricalComponent` gains fields and deprecates
  `manufacturer`/`model_name`. See `RELEASE_NOTES.md` → Upgrading.