### PR TITLE
Add steam boiler support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ cargo add --dev frequenz-microgrid --features test-utils
 
 ## What's included
 
-- `Microgrid` / `LogicalMeterHandle`: typed formulas for grid, battery, pv, chp, ev_charger, consumer, producer, and individual components, parametrised over a metric.
-- `BatteryPool` and `PvPool`: aggregated active-power bounds and health-partitioned telemetry for a set of batteries or PV inverters.
+- `Microgrid` / `LogicalMeterHandle`: typed formulas for grid, battery, pv, chp, ev_charger, steam_boiler, consumer, producer, and individual components, parametrised over a metric.
+- `BatteryPool`, `PvPool` and `SteamBoilerPool`: aggregated active-power bounds and health-partitioned telemetry for a set of batteries, PV inverters or steam boilers.
 - `MicrogridClientHandle`: cloneable low-level gRPC handle with per-stream automatic reconnect.
 - Typed quantities — `Power`, `Current`, `Voltage`, `ReactivePower`, `Energy`, `Frequency`, `Percentage` — with unit conversions explicit at every API surface.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,12 +1,17 @@
 # Frequenz Microgrid Release Notes
 
+## Summary
+
+<!-- Here goes a general summary of what this release is about -->
+
 ## Upgrading
 
-- The bundled Microgrid API protos moved to `frequenz-api-microgrid` v0.19.0 (`frequenz-api-common` v0.8.4). The re-exported `client::ElectricalComponentCategory` gained the `SteamBoiler` variant; an exhaustive `match` on it needs a new arm.
-- `client::ElectricalComponent` gained the fields `operational_mode` and `model` (`manufacturer` and `model_name` are deprecated in favour of `model`); struct literals need `..Default::default()`.
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
 ## New Features
 
-- Component operational modes are passed to the component graph. Formulas no longer read components whose mode is `Inactive` or `ControlOnly`; for such a component, `LogicalMeterHandle::component()` returns a formula with no reading.
-- The crate now requires `frequenz-microgrid-component-graph` 0.6.2 (was 0.6.0), which brings the operational-mode support and formula fixes; see its release notes.
-- `test-utils`: `MockComponent::with_operational_mode()` sets a mock component's operational mode.
+<!-- Here goes the main new features and examples or instructions on how to use them -->
+
+## Bug Fixes
+
+<!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,9 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+- `LogicalMeterHandle::steam_boiler::<M>()` streams a metric for a set of steam boilers.
+- `Microgrid::steam_boiler_pool()` returns a `SteamBoilerPool` with the pool's active power, aggregated active-power bounds and health-partitioned telemetry snapshots.
+- `test-utils`: `MockComponent::steam_boiler()` builds a steam boiler, and `MockComponent::add_power_bounds()` attaches bounds to a component's streamed active-power samples.
 
 ## Bug Fixes
 

--- a/src/client/microgrid_client_handle.rs
+++ b/src/client/microgrid_client_handle.rs
@@ -174,7 +174,7 @@ impl MicrogridClientHandle {
     /// which the bounds will stay in effect. If no duration is provided, then the
     /// bounds will be removed after a default duration of 5 seconds.
     ///
-    /// Inclusion bounds give the range that the system will try to keep the
+    /// The bounds give the range that the system will try to keep the
     /// metric within. If the metric goes outside of these bounds, the system will
     /// try to bring it back within the bounds.
     /// If the bounds for a metric are [\`lower_1`, `upper_1`],
@@ -183,7 +183,7 @@ impl MicrogridClientHandle {
     /// the constraints
     /// `lower_1 <= value <= upper_1` OR `lower_2 <= value <= upper_2`.
     ///
-    /// If multiple inclusion bounds have been provided for a metric, then the
+    /// If multiple bounds have been provided for a metric, then the
     /// overlapping bounds are merged into a single bound, and non-overlapping
     /// bounds are kept separate.
     /// E.g. if the bounds are [0, 10], [5, 15], [20, 30](<0, 10], [5, 15], [20, 30>), then the resulting

--- a/src/client/test_utils.rs
+++ b/src/client/test_utils.rs
@@ -179,6 +179,18 @@ impl MockComponent {
         }
     }
 
+    pub fn steam_boiler(component_id: u64) -> Self {
+        Self {
+            component: ElectricalComponent {
+                id: component_id,
+                name: format!("Steam Boiler {}", component_id),
+                category: ElectricalComponentCategory::SteamBoiler as i32,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
     pub fn with_children(mut self, children: Vec<MockComponent>) -> Self {
         if self.component.category == ElectricalComponentCategory::Unspecified as i32 {
             panic!("Cannot add children to a hidden load component");

--- a/src/client/test_utils.rs
+++ b/src/client/test_utils.rs
@@ -82,6 +82,9 @@ pub struct MockComponent {
     /// prevents the client actor from reconnecting and replaying the same
     /// data. Useful for testing missing-data timeouts.
     silence_after_metrics: bool,
+    /// Bounds attached to every streamed `AcPowerActive` sample. Set via
+    /// [`MockComponent::add_power_bounds`]; empty by default.
+    power_bounds: Vec<Bounds>,
 }
 
 impl MockComponent {
@@ -297,6 +300,14 @@ impl MockComponent {
         self
     }
 
+    /// Attaches bounds `lower..upper` to every streamed active-power
+    /// sample, so pool bounds trackers have something to aggregate. Call it
+    /// again to attach a second, disjoint range.
+    pub fn add_power_bounds(mut self, lower: Option<f32>, upper: Option<f32>) -> Self {
+        self.power_bounds.push(Bounds { lower, upper });
+        self
+    }
+
     /// Keeps the telemetry stream open and silent after the configured
     /// metrics are exhausted, so the client actor doesn't reconnect and
     /// replay the data. Useful for testing missing-data timeouts.
@@ -430,6 +441,7 @@ impl MicrogridApiClient for MockMicrogridApiClient {
                 .state_code
                 .unwrap_or(ElectricalComponentStateCode::Ready);
             let silence_after_metrics = component.silence_after_metrics;
+            let power_bounds = component.power_bounds.clone();
             let clock = self.clock.clone();
             tokio::spawn(async move {
                 let dur = std::time::Duration::from_millis(200);
@@ -470,7 +482,7 @@ impl MicrogridApiClient for MockMicrogridApiClient {
                                     ),
                                 ),
                             }),
-                            bounds: vec![],
+                            bounds: power_bounds.clone(),
                             connection: None,
                         });
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,8 @@ pub(crate) mod wall_clock_timer;
 mod microgrid;
 pub use microgrid::{
     BatteryPool, BatteryPoolSnapshot, ComponentHealthPartition, InverterBatteryGroup,
-    InverterBatteryGroupStatus, Microgrid, PvPool, PvPoolSnapshot,
+    InverterBatteryGroupStatus, Microgrid, PvPool, PvPoolSnapshot, SteamBoilerPool,
+    SteamBoilerPoolSnapshot,
 };
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/src/logical_meter/formula/graph_formula_provider.rs
+++ b/src/logical_meter/formula/graph_formula_provider.rs
@@ -52,6 +52,7 @@ pub(crate) trait GraphFormulaProvider: Sized {
         (chp, ids: _chp_ids),
         (pv, ids: _pv_inverter_ids),
         (ev_charger, ids: _ev_charger_ids),
+        (steam_boiler, ids: _steam_boiler_ids),
         (component, id: _component_id),
     );
 }
@@ -92,6 +93,7 @@ impl<M: Metric> GraphFormulaProvider for AggregationFormula<M> {
         (chp, chp_formula, ids: chp_ids),
         (pv, pv_formula, ids: pv_inverter_ids),
         (ev_charger, ev_charger_formula, ids: ev_charger_ids),
+        (steam_boiler, steam_boiler_formula, ids: steam_boiler_ids),
         (component, component_formula, id: component_id),
     );
 }

--- a/src/logical_meter/logical_meter_handle.rs
+++ b/src/logical_meter/logical_meter_handle.rs
@@ -142,6 +142,22 @@ impl LogicalMeterHandle {
     }
 
     /// Returns a receiver that streams samples for the given `metric` for the
+    /// given steam boiler IDs.
+    ///
+    /// When `component_ids` is `None`, all steam boilers in the microgrid are
+    /// used.
+    pub fn steam_boiler<M: metric::Metric>(
+        &self,
+        component_ids: Option<BTreeSet<u64>>,
+    ) -> Result<Formula<M::QuantityType>, Error> {
+        Ok(Formula::Subscriber(Box::new(M::FormulaType::steam_boiler(
+            &self.graph,
+            self.instructions_tx.clone(),
+            component_ids,
+        )?)))
+    }
+
+    /// Returns a receiver that streams samples for the given `metric` for the
     /// logical `consumer` in the microgrid.
     pub fn consumer<M: metric::Metric>(&self) -> Result<Formula<M::QuantityType>, Error> {
         Ok(Formula::Subscriber(Box::new(M::FormulaType::consumer(
@@ -266,6 +282,11 @@ mod tests {
                             MockComponent::ev_charger(14),
                             MockComponent::ev_charger(15),
                         ]),
+                        // Steam boiler meter
+                        MockComponent::meter(16).with_children(vec![
+                            // Steam boiler
+                            MockComponent::steam_boiler(17),
+                        ]),
                     ]),
             ]),
         );
@@ -339,6 +360,44 @@ mod tests {
             "METRIC_AC_CURRENT::(COALESCE(#15 + #14, #13, COALESCE(#15, 0.0) + COALESCE(#14, 0.0)))"
         );
 
+        let formula = lm
+            .steam_boiler::<crate::metric::AcPowerActive>(None)
+            .unwrap();
+        assert_eq!(
+            formula.to_string(),
+            "METRIC_AC_POWER_ACTIVE::(COALESCE(#17, #16, 0.0))"
+        );
+
+        let formula = lm
+            .steam_boiler::<crate::metric::AcPowerActive>(Some([17].into()))
+            .unwrap();
+        assert_eq!(
+            formula.to_string(),
+            "METRIC_AC_POWER_ACTIVE::(COALESCE(#17, #16, 0.0))"
+        );
+
+        // 16 is the steam boiler's meter, not a steam boiler.
+        let err = lm
+            .steam_boiler::<crate::metric::AcPowerActive>(Some([16].into()))
+            .err()
+            .expect("a non-steam-boiler ID must be rejected");
+        assert!(
+            err.to_string().contains("is not a steam boiler"),
+            "unexpected error: {err}"
+        );
+
+        // Only the aggregation path exists for steam boilers (as for CHP), so a
+        // coalesce metric is unsupported.
+        let err = lm
+            .steam_boiler::<crate::metric::AcVoltage>(None)
+            .err()
+            .expect("coalesce metrics are unsupported for steam boilers");
+        assert!(
+            err.to_string()
+                .contains("does not support steam_boiler formula generation"),
+            "unexpected error: {err}"
+        );
+
         let formula = lm.consumer::<crate::metric::AcCurrent>().unwrap();
         assert_eq!(
             formula.to_string(),
@@ -346,11 +405,13 @@ mod tests {
                 "METRIC_AC_CURRENT::(MAX(",
                 "#2 - COALESCE(#3, #4, 0.0) - COALESCE(#5, COALESCE(#8, 0.0) + COALESCE(#6, 0.0)) ",
                 "- #10 - COALESCE(#11, #12, 0.0)",
-                " - COALESCE(#13, COALESCE(#15, 0.0) + COALESCE(#14, 0.0)),",
+                " - COALESCE(#13, COALESCE(#15, 0.0) + COALESCE(#14, 0.0))",
+                " - COALESCE(#16, #17, 0.0),",
                 " 0.0)",
                 " + COALESCE(MAX(#3 - #4, 0.0), 0.0) + COALESCE(MAX(#5 - #6 - #8, 0.0), 0.0)",
                 " + MAX(#10, 0.0) + COALESCE(MAX(#11 - #12, 0.0), 0.0)",
                 " + COALESCE(MAX(#13 - #14 - #15, 0.0), 0.0)",
+                " + COALESCE(MAX(#16 - #17, 0.0), 0.0)",
                 ")"
             )
         );

--- a/src/microgrid.rs
+++ b/src/microgrid.rs
@@ -18,6 +18,9 @@ pub use battery_pool::BatteryPool;
 mod pv_pool;
 pub use pv_pool::PvPool;
 
+mod steam_boiler_pool;
+pub use steam_boiler_pool::SteamBoilerPool;
+
 pub(crate) mod telemetry_tracker;
 pub use telemetry_tracker::battery_pool_telemetry_tracker::{
     BatteryPoolSnapshot, InverterBatteryGroup,
@@ -25,6 +28,7 @@ pub use telemetry_tracker::battery_pool_telemetry_tracker::{
 pub use telemetry_tracker::component_partition::ComponentHealthPartition;
 pub use telemetry_tracker::inverter_battery_group_telemetry_tracker::InverterBatteryGroupStatus;
 pub use telemetry_tracker::pv_pool_telemetry_tracker::PvPoolSnapshot;
+pub use telemetry_tracker::steam_boiler_pool_telemetry_tracker::SteamBoilerPoolSnapshot;
 
 use crate::{Error, LogicalMeterConfig, LogicalMeterHandle, MicrogridClientHandle};
 
@@ -88,6 +92,17 @@ impl Microgrid {
 
     pub fn pv_pool(&self, component_ids: Option<Vec<u64>>) -> Result<PvPool, Error> {
         PvPool::try_new(
+            component_ids.map(|ids| ids.into_iter().collect()),
+            self.client.clone(),
+            self.logical_meter.clone(),
+        )
+    }
+
+    pub fn steam_boiler_pool(
+        &self,
+        component_ids: Option<Vec<u64>>,
+    ) -> Result<SteamBoilerPool, Error> {
+        SteamBoilerPool::try_new(
             component_ids.map(|ids| ids.into_iter().collect()),
             self.client.clone(),
             self.logical_meter.clone(),

--- a/src/microgrid/pool_bounds.rs
+++ b/src/microgrid/pool_bounds.rs
@@ -1,19 +1,21 @@
 // License: MIT
 // Copyright © 2026 Frequenz Energy-as-a-Service GmbH
 
-//! Pool-level bounds aggregation for PV and battery pools.
+//! Pool-level bounds aggregation for PV, steam boiler and battery pools.
 //!
 //! Each pool's healthy components have their per-metric bounds combined into a
-//! single pool-level set. PV inverters in a pool are wired in parallel, so their
-//! bounds are simply added together. A battery pool aggregates following the
-//! physical topology of its inverter-battery groups (parallel within a side,
-//! series between the inverter and battery sides, parallel across groups).
+//! single pool-level set. The PV inverters or steam boilers in a pool are wired
+//! in parallel, so their bounds are simply added together. A battery pool
+//! aggregates following the physical topology of its inverter-battery groups
+//! (parallel within a side, series between the inverter and battery sides,
+//! parallel across groups).
 
 use crate::bounds::{combine_parallel_sets, intersect_bounds_sets};
 use crate::client::proto::common::metrics::Bounds as PbBounds;
 use crate::microgrid::bounds_aggregation::aggregate_parallel;
 use crate::microgrid::telemetry_tracker::battery_pool_telemetry_tracker::BatteryPoolSnapshot;
 use crate::microgrid::telemetry_tracker::pv_pool_telemetry_tracker::PvPoolSnapshot;
+use crate::microgrid::telemetry_tracker::steam_boiler_pool_telemetry_tracker::SteamBoilerPoolSnapshot;
 use crate::{Bounds, metric::Metric};
 
 /// Aggregates the bounds of every healthy PV inverter in the pool. The
@@ -27,6 +29,21 @@ where
     Bounds<M::QuantityType>: From<PbBounds>,
 {
     aggregate_parallel::<M>(&status.inverters.healthy)
+}
+
+/// Aggregates the bounds of every healthy steam boiler in the pool. The
+/// boilers are wired in parallel, so their bounds combine in parallel.
+///
+/// `M` is the metric used to read bounds from the steam boilers (e.g.
+/// `AcPowerActive`).
+pub(crate) fn compute_steam_boiler_pool_bounds<M>(
+    status: &SteamBoilerPoolSnapshot,
+) -> Vec<Bounds<M::QuantityType>>
+where
+    M: Metric,
+    Bounds<M::QuantityType>: From<PbBounds>,
+{
+    aggregate_parallel::<M>(&status.boilers.healthy)
 }
 
 /// Aggregates the power bounds of a battery pool following the physical

--- a/src/microgrid/steam_boiler_pool.rs
+++ b/src/microgrid/steam_boiler_pool.rs
@@ -1,0 +1,402 @@
+// License: MIT
+// Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+//! Representation of a pool of steam boilers in the microgrid.
+//!
+//! A [`SteamBoilerPool`] aggregates a set of steam boilers — either an explicit
+//! subset or every steam boiler in the microgrid — and exposes their combined
+//! active power, their aggregated active-power bounds, and a
+//! health-partitioned telemetry snapshot stream.
+//!
+//! Obtain one from [`Microgrid::steam_boiler_pool`]; see [`SteamBoilerPool`]
+//! for a usage example.
+//!
+//! [`Microgrid::steam_boiler_pool`]: crate::Microgrid::steam_boiler_pool
+
+use tokio::sync::broadcast;
+
+use std::collections::{BTreeSet, HashSet};
+use std::time::Duration;
+
+use crate::{
+    Bounds, Error, Formula, LogicalMeterHandle, MicrogridClientHandle,
+    client::proto::common::microgrid::electrical_components::{
+        ElectricalComponentCategory, ElectricalComponentStateCode,
+    },
+    metric,
+    metric::Metric,
+    microgrid::{
+        caching_sender::{CachingSender, WeakCachingSender},
+        pool_bounds,
+        pool_bounds_tracker::PoolBoundsTracker,
+        pool_validation::validate_pool_ids,
+        telemetry_tracker::steam_boiler_pool_telemetry_tracker::{
+            SteamBoilerPoolSnapshot, SteamBoilerPoolTelemetryTracker,
+        },
+    },
+    quantity::Power,
+};
+
+/// A pool of steam boilers in the microgrid.
+///
+/// Created with [`Microgrid::steam_boiler_pool`][mg], passing either an
+/// explicit set of steam boiler component IDs or `None` to cover every steam
+/// boiler in the microgrid. It exposes:
+///
+/// - [`power`](Self::power) — a [`Formula`] for the pool's aggregate active
+///   power (passive sign convention: positive while the boilers consume);
+/// - [`power_bounds`](Self::power_bounds) — a stream of the pool's aggregated
+///   active-power bounds;
+/// - [`telemetry_snapshots`](Self::telemetry_snapshots) — a stream of
+///   [`SteamBoilerPoolSnapshot`]s partitioning the boilers into healthy and
+///   unhealthy sets.
+///
+/// The bounds and snapshot streams share a telemetry tracker that is started on
+/// first use and reused while it still has live receivers.
+///
+/// # Example
+///
+/// ```no_run
+/// # async fn example() -> Result<(), frequenz_microgrid::Error> {
+/// use chrono::TimeDelta;
+/// use frequenz_microgrid::{LogicalMeterConfig, Microgrid};
+///
+/// let microgrid = Microgrid::try_new(
+///     "grpc://localhost:50051",
+///     LogicalMeterConfig::new(TimeDelta::try_seconds(1).unwrap()),
+/// )
+/// .await?;
+///
+/// // A pool over every steam boiler in the microgrid.
+/// let mut boilers = microgrid.steam_boiler_pool(None)?;
+///
+/// // Subscribe to the pool's aggregated active-power bounds.
+/// let mut bounds_rx = boilers.power_bounds();
+/// while let Ok(bounds) = bounds_rx.recv().await {
+///     println!("Steam boiler pool active-power bounds: {bounds:?}");
+/// }
+/// # Ok(())
+/// # }
+/// ```
+///
+/// [mg]: crate::Microgrid::steam_boiler_pool
+pub struct SteamBoilerPool {
+    component_ids: Option<BTreeSet<u64>>,
+    client: MicrogridClientHandle,
+    logical_meter: LogicalMeterHandle,
+    snapshot_tx: Option<WeakCachingSender<SteamBoilerPoolSnapshot>>,
+    bounds_tx: Option<WeakCachingSender<Vec<Bounds<Power>>>>,
+}
+
+impl SteamBoilerPool {
+    /// Creates a new `SteamBoilerPool` instance with the given component IDs,
+    /// client and logical meter handles.
+    ///
+    /// When `component_ids` is `Some`, every ID must refer to a steam boiler in
+    /// the component graph; otherwise an error is returned. When it is `None`,
+    /// the pool covers all steam boilers in the microgrid.
+    pub(crate) fn try_new(
+        component_ids: Option<BTreeSet<u64>>,
+        client: MicrogridClientHandle,
+        logical_meter: LogicalMeterHandle,
+    ) -> Result<Self, Error> {
+        let this = Self {
+            component_ids,
+            client,
+            logical_meter,
+            snapshot_tx: None,
+            bounds_tx: None,
+        };
+        validate_pool_ids(
+            &this.component_ids,
+            &this.get_all_steam_boiler_ids(),
+            "steam boilers",
+        )
+        .inspect_err(|e| tracing::error!("{e}"))?;
+        Ok(this)
+    }
+
+    fn get_all_steam_boiler_ids(&self) -> BTreeSet<u64> {
+        self.logical_meter
+            .graph()
+            .components()
+            .filter(|c| c.category() == ElectricalComponentCategory::SteamBoiler)
+            .map(|c| c.id)
+            .collect()
+    }
+
+    fn get_steam_boiler_ids(&self) -> BTreeSet<u64> {
+        if let Some(ids) = &self.component_ids {
+            ids.clone()
+        } else {
+            self.get_all_steam_boiler_ids()
+        }
+    }
+
+    /// Returns a formula for the active power of the steam boiler pool.
+    pub fn power(&mut self) -> Result<Formula<Power>, Error> {
+        self.logical_meter
+            .steam_boiler::<metric::AcPowerActive>(self.component_ids.clone())
+    }
+
+    /// Returns a receiver for the aggregated active-power bounds of the pool,
+    /// updated on each snapshot.
+    ///
+    /// Reuses the running bounds tracker if one exists and still has active
+    /// receivers; otherwise starts a new one (which also starts or reuses the
+    /// underlying telemetry tracker).
+    pub fn power_bounds(&mut self) -> broadcast::Receiver<Vec<Bounds<Power>>> {
+        if let Some(tx) = self.bounds_tx.as_ref().and_then(WeakCachingSender::upgrade)
+            && tx.receiver_count() > 0
+        {
+            return tx.subscribe_with_current();
+        }
+        let snapshot_rx = self.telemetry_snapshots();
+        let tx = CachingSender::<Vec<Bounds<Power>>>::new();
+        // Subscribe before spawning so the tracker sees a receiver and doesn't
+        // stop before this consumer has read anything.
+        let rx = tx.subscribe_with_current();
+        let tracker = PoolBoundsTracker::new(
+            snapshot_rx,
+            tx.clone(),
+            pool_bounds::compute_steam_boiler_pool_bounds::<metric::AcPowerActive>,
+            format!("{} steam boiler", metric::AcPowerActive::str_name()),
+        );
+        tokio::spawn(tracker.run());
+        self.bounds_tx = Some(tx.downgrade());
+        rx
+    }
+
+    /// Returns a receiver for a stream of [`SteamBoilerPoolSnapshot`] values,
+    /// each reflecting the latest boiler telemetry partitioned into healthy and
+    /// unhealthy sets.
+    ///
+    /// Reuses the running tracker if one exists and still has active receivers
+    /// (including any held by a bounds tracker); otherwise starts a new one.
+    pub fn telemetry_snapshots(&mut self) -> broadcast::Receiver<SteamBoilerPoolSnapshot> {
+        if let Some(tx) = self
+            .snapshot_tx
+            .as_ref()
+            .and_then(WeakCachingSender::upgrade)
+            && tx.receiver_count() > 0
+        {
+            return tx.subscribe_with_current();
+        }
+        let tx = CachingSender::<SteamBoilerPoolSnapshot>::new();
+        // Subscribe before spawning so the tracker sees a receiver and doesn't
+        // stop before this consumer has read anything.
+        let rx = tx.subscribe_with_current();
+        let tracker = SteamBoilerPoolTelemetryTracker::new(
+            self.get_steam_boiler_ids(),
+            Duration::from_secs(10),
+            // Operational states in which a steam boiler is alive and
+            // reporting usable telemetry: heating (Charging) or idle and
+            // ready (Ready).
+            HashSet::from([
+                ElectricalComponentStateCode::Ready,
+                ElectricalComponentStateCode::Charging,
+            ]),
+            self.client.clone(),
+            tx.clone(),
+        );
+        tokio::spawn(tracker.run());
+        self.snapshot_tx = Some(tx.downgrade());
+        rx
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::SteamBoilerPool;
+    use crate::Bounds;
+    use crate::client::proto::common::microgrid::electrical_components::ElectricalComponentStateCode;
+    use crate::client::test_utils::MockComponent;
+    use crate::microgrid::test_utils::{handles, last_snapshot};
+    use crate::quantity::Power;
+
+    /// grid → meter → [boiler meter → steam_boiler(4), steam_boiler(5)],
+    ///                 [chp meter → chp(7)]
+    fn graph() -> MockComponent {
+        MockComponent::grid(1).with_children(vec![MockComponent::meter(2).with_children(vec![
+            MockComponent::meter(3).with_children(vec![
+                MockComponent::steam_boiler(4),
+                MockComponent::steam_boiler(5),
+            ]),
+            MockComponent::meter(6).with_children(vec![MockComponent::chp(7)]),
+        ])])
+    }
+
+    #[tokio::test]
+    async fn try_new_accepts_empty_component_ids() {
+        let (client, lm) = handles(graph()).await;
+        let mut pool = SteamBoilerPool::try_new(Some(BTreeSet::new()), client, lm)
+            .expect("an empty component_ids set should yield an empty pool");
+        pool.power().expect("empty pool power formula");
+    }
+
+    #[tokio::test]
+    async fn try_new_rejects_non_steam_boiler_component_ids() {
+        let (client, lm) = handles(graph()).await;
+        // 7 is a CHP: a valid component, but not a steam boiler.
+        let err = SteamBoilerPool::try_new(Some([7].into()), client, lm)
+            .err()
+            .expect("a CHP ID should be rejected");
+        assert!(
+            err.to_string().contains("must be steam boilers"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn try_new_rejects_unknown_component_ids() {
+        let (client, lm) = handles(graph()).await;
+        // 99 is not in the graph at all.
+        let err = SteamBoilerPool::try_new(Some([4, 99].into()), client, lm)
+            .err()
+            .expect("an unknown ID should be rejected");
+        assert!(
+            err.to_string().contains("must be steam boilers"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn power_formula_for_all_steam_boilers() {
+        let (client, lm) = handles(graph()).await;
+        let mut pool = SteamBoilerPool::try_new(None, client, lm).unwrap();
+        assert_eq!(
+            pool.power().unwrap().to_string(),
+            "METRIC_AC_POWER_ACTIVE::(COALESCE(#5 + #4, #3, COALESCE(#5, 0.0) + COALESCE(#4, 0.0)))"
+        );
+    }
+
+    #[tokio::test]
+    async fn power_formula_for_explicit_steam_boiler() {
+        let (client, lm) = handles(graph()).await;
+        let mut pool = SteamBoilerPool::try_new(Some([4].into()), client, lm).unwrap();
+        assert_eq!(
+            pool.power().unwrap().to_string(),
+            "METRIC_AC_POWER_ACTIVE::(COALESCE(#4, #3 - #5, 0.0))"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn empty_pool_emits_empty_snapshot_and_bounds() {
+        // grid → meter, with no steam boilers anywhere.
+        let (client, lm) =
+            handles(MockComponent::grid(1).with_children(vec![MockComponent::meter(2)])).await;
+        let mut pool = SteamBoilerPool::try_new(None, client, lm).unwrap();
+
+        let mut snapshots = pool.telemetry_snapshots();
+        let mut bounds = pool.power_bounds();
+
+        let snapshot = last_snapshot(&mut snapshots, 5).await;
+        assert!(
+            snapshot.boilers.healthy.is_empty() && snapshot.boilers.unhealthy.is_empty(),
+            "empty pool snapshot should have no boilers, got {snapshot:?}"
+        );
+        assert!(
+            last_snapshot(&mut bounds, 5).await.is_empty(),
+            "empty pool should have empty power bounds"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reporting_boilers_are_healthy_and_their_bounds_add() {
+        // grid → meter → [steam_boiler(3), steam_boiler(4)], both reporting
+        // power with bounds 0..1000 W and 0..2000 W.
+        let (client, lm) = handles(MockComponent::grid(1).with_children(vec![
+            MockComponent::meter(2).with_children(vec![
+                MockComponent::steam_boiler(3)
+                    .with_power(vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+                    .add_power_bounds(Some(0.0), Some(1000.0)),
+                MockComponent::steam_boiler(4)
+                    .with_power(vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+                    .add_power_bounds(Some(0.0), Some(2000.0)),
+            ]),
+        ]))
+        .await;
+        let mut pool = SteamBoilerPool::try_new(None, client, lm).unwrap();
+
+        let mut snapshots = pool.telemetry_snapshots();
+        let mut bounds = pool.power_bounds();
+
+        let snap = last_snapshot(&mut snapshots, 10).await;
+        assert!(snap.boilers.healthy.contains_key(&3));
+        assert!(snap.boilers.healthy.contains_key(&4));
+        assert!(snap.boilers.unhealthy.is_empty());
+
+        assert_eq!(
+            last_snapshot(&mut bounds, 5).await,
+            vec![Bounds::new(
+                Some(Power::from_watts(0.0)),
+                Some(Power::from_watts(3000.0))
+            )]
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn boiler_with_bad_state_is_unhealthy() {
+        // Standby is healthy for a PV inverter but not for a steam boiler.
+        let (client, lm) = handles(MockComponent::grid(1).with_children(vec![
+            MockComponent::meter(2).with_children(vec![
+                MockComponent::steam_boiler(3)
+                    .with_power(vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+                    .with_state(ElectricalComponentStateCode::Standby),
+            ]),
+        ]))
+        .await;
+        let mut pool = SteamBoilerPool::try_new(None, client, lm).unwrap();
+
+        let mut rx = pool.telemetry_snapshots();
+        let snap = last_snapshot(&mut rx, 10).await;
+
+        assert!(snap.boilers.healthy.is_empty());
+        assert!(snap.boilers.unhealthy.contains_key(&3), "got {snap:?}");
+        // The Standby sample was received and rejected, not just never seen.
+        assert!(
+            snap.boilers.unhealthy[&3].is_some(),
+            "bad-state sample should be stored, got {snap:?}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn charging_boiler_is_healthy() {
+        // Charging is the boiler's "heating" state and counts as healthy.
+        let (client, lm) = handles(MockComponent::grid(1).with_children(vec![
+            MockComponent::meter(2).with_children(vec![
+                MockComponent::steam_boiler(3)
+                    .with_power(vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+                    .with_state(ElectricalComponentStateCode::Charging),
+            ]),
+        ]))
+        .await;
+        let mut pool = SteamBoilerPool::try_new(None, client, lm).unwrap();
+
+        let mut rx = pool.telemetry_snapshots();
+        let snap = last_snapshot(&mut rx, 10).await;
+
+        assert!(snap.boilers.healthy.contains_key(&3), "got {snap:?}");
+        assert!(snap.boilers.unhealthy.is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn calling_power_bounds_twice_reuses_the_tracker() {
+        let (client, lm) = handles(graph()).await;
+        let mut pool = SteamBoilerPool::try_new(None, client, lm).unwrap();
+
+        let mut rx1 = pool.power_bounds();
+        let bounds1 = last_snapshot(&mut rx1, 10).await;
+
+        // A second call while rx1 is alive must reuse the running tracker, which
+        // re-sends its cached bounds at once; a fresh tracker's cache would be
+        // empty until it ran.
+        let mut rx2 = pool.power_bounds();
+        let bounds2 = rx2
+            .try_recv()
+            .expect("reused tracker should re-send its cached bounds immediately");
+        assert_eq!(bounds1, bounds2);
+    }
+}

--- a/src/microgrid/telemetry_tracker.rs
+++ b/src/microgrid/telemetry_tracker.rs
@@ -12,3 +12,4 @@ pub(crate) mod component_partition;
 pub(crate) mod component_telemetry_tracker;
 pub(crate) mod inverter_battery_group_telemetry_tracker;
 pub(crate) mod pv_pool_telemetry_tracker;
+pub(crate) mod steam_boiler_pool_telemetry_tracker;

--- a/src/microgrid/telemetry_tracker/steam_boiler_pool_telemetry_tracker.rs
+++ b/src/microgrid/telemetry_tracker/steam_boiler_pool_telemetry_tracker.rs
@@ -1,0 +1,156 @@
+// License: MIT
+// Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+//! A telemetry tracker for a pool of steam boilers.
+//!
+//! The tracker spawns a [`ComponentTelemetryTracker`] per boiler and emits a
+//! [`SteamBoilerPoolSnapshot`], partitioning the boilers into healthy and unhealthy
+//! sets, whenever any boiler's telemetry or health classification changes.
+
+use std::{
+    collections::{BTreeSet, HashSet},
+    time::Duration,
+};
+
+use tokio::sync::mpsc;
+
+use crate::{
+    MicrogridClientHandle,
+    client::proto::common::microgrid::electrical_components::ElectricalComponentStateCode,
+    microgrid::caching_sender::CachingSender,
+};
+
+use super::component_partition::ComponentHealthPartition;
+use super::component_telemetry_tracker::{ComponentHealthStatus, ComponentTelemetryTracker};
+
+/// A snapshot of a steam boiler pool's boilers, partitioned by health status and
+/// annotated with the latest telemetry sample for each (see
+/// [`ComponentHealthPartition`]).
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct SteamBoilerPoolSnapshot {
+    pub boilers: ComponentHealthPartition,
+}
+
+/// A tracker that watches every steam boiler in the pool and emits a
+/// [`SteamBoilerPoolSnapshot`] whenever any boiler's telemetry or health
+/// classification changes.
+#[derive(Clone)]
+pub(crate) struct SteamBoilerPoolTelemetryTracker {
+    component_ids: BTreeSet<u64>,
+    component_pool_status_tx: CachingSender<SteamBoilerPoolSnapshot>,
+    missing_data_tolerance: Duration,
+    healthy_state_codes: HashSet<ElectricalComponentStateCode>,
+    client: MicrogridClientHandle,
+}
+
+impl SteamBoilerPoolTelemetryTracker {
+    pub(crate) fn new(
+        component_ids: BTreeSet<u64>,
+        missing_data_tolerance: Duration,
+        healthy_state_codes: HashSet<ElectricalComponentStateCode>,
+        client: MicrogridClientHandle,
+        component_pool_status_tx: CachingSender<SteamBoilerPoolSnapshot>,
+    ) -> Self {
+        Self {
+            component_ids,
+            component_pool_status_tx,
+            missing_data_tolerance,
+            healthy_state_codes,
+            client,
+        }
+    }
+
+    pub(crate) async fn run(self) {
+        let mut snapshot = SteamBoilerPoolSnapshot::default();
+        for &boiler_id in &self.component_ids {
+            // Every boiler starts unhealthy until it reports data.
+            snapshot.boilers.mark_unhealthy(boiler_id, None);
+        }
+
+        // Publish the initial partition before opening any telemetry streams, so
+        // a subscriber reading before the first update sees the pool's real
+        // boilers (all unhealthy until data arrives) rather than the channel's
+        // empty default. For an empty pool this is the single empty snapshot.
+        // A fresh subscriber gets it (or its cached copy) at once. Ignore "no
+        // receivers" here — the tick loop below owns shutdown.
+        let _ = self.component_pool_status_tx.publish(snapshot.clone());
+
+        let (status_tx, mut status_rx) = mpsc::channel(100);
+        for &boiler_id in &self.component_ids {
+            let component_data_stream = match self
+                .client
+                .receive_electrical_component_telemetry_stream(boiler_id)
+                .await
+            {
+                Ok(stream) => stream,
+                Err(e) => {
+                    tracing::error!(
+                        "Internal error opening telemetry stream for steam boiler {boiler_id}: {e}; steam boiler pool telemetry tracker aborting.",
+                    );
+                    return;
+                }
+            };
+            let tracker = ComponentTelemetryTracker::new(
+                boiler_id,
+                self.missing_data_tolerance,
+                self.healthy_state_codes.clone(),
+                component_data_stream,
+                status_tx.clone(),
+            );
+            // Spawn a task for each component telemetry tracker.
+            tokio::spawn(async move {
+                tracker.run().await;
+            });
+        }
+
+        // Drop the original sender so the channel closes once every component
+        // tracker finishes, ending the loop below. An empty pool spawns no
+        // trackers, so keep the sender instead: `status_rx.recv()` then parks,
+        // and the tick loop drives the (empty) snapshot and the receiver-count
+        // shutdown check — so the task stops when its consumers go, not before.
+        let _empty_pool_keepalive = if self.component_ids.is_empty() {
+            Some(status_tx)
+        } else {
+            drop(status_tx);
+            None
+        };
+
+        let mut interval = tokio::time::interval(Duration::from_millis(200));
+
+        loop {
+            tokio::select! {
+                maybe_status = status_rx.recv() => {
+                    match maybe_status {
+                        Some(ComponentHealthStatus::Healthy(id, data)) => {
+                            snapshot.boilers.mark_healthy(id, data);
+                        }
+                        Some(ComponentHealthStatus::Unhealthy(id, data)) => {
+                            snapshot.boilers.mark_unhealthy(id, data);
+                        }
+                        // Every component tracker has exited and dropped its
+                        // sender, so no further updates will ever arrive. The
+                        // `_ = interval.tick()` arm below is a catch-all that
+                        // never disables, so the `select!` `else` branch can
+                        // never run; break here instead.
+                        None => break,
+                    }
+                },
+                _ = interval.tick() => {
+                    // Publish only when the partition changed (compared whole, so
+                    // a future field can't escape detection); either way, stop
+                    // once the last consumer has dropped.
+                    if !self.component_pool_status_tx.publish_if_changed(&snapshot) {
+                        break;
+                    }
+                },
+            }
+        }
+
+        // Reaching here means either every consumer dropped or every component
+        // tracker exited — a normal shutdown, not an error.
+        tracing::debug!(
+            "SteamBoilerPoolTelemetryTracker (component IDs {:?}) stopped: all consumers or component trackers are gone.",
+            self.component_ids
+        );
+    }
+}

--- a/src/microgrid/telemetry_tracker/steam_boiler_pool_telemetry_tracker.rs
+++ b/src/microgrid/telemetry_tracker/steam_boiler_pool_telemetry_tracker.rs
@@ -154,3 +154,138 @@ impl SteamBoilerPoolTelemetryTracker {
         );
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::client::proto::common::microgrid::electrical_components::ElectricalComponentStateCode;
+    use crate::client::test_utils::MockComponent;
+    use crate::microgrid::steam_boiler_pool::SteamBoilerPool;
+    use crate::microgrid::test_utils::{handles, last_snapshot};
+
+    async fn new_pool(graph: MockComponent) -> SteamBoilerPool {
+        let (client, lm) = handles(graph).await;
+        SteamBoilerPool::try_new(None, client, lm).unwrap()
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn single_boiler_reaches_healthy_state() {
+        // grid → meter → steam_boiler(3)
+        let mut pool = new_pool(MockComponent::grid(1).with_children(vec![
+            MockComponent::meter(2).with_children(vec![
+                MockComponent::steam_boiler(3).with_power(vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+            ]),
+        ]))
+        .await;
+
+        let mut rx = pool.telemetry_snapshots();
+        let snap = last_snapshot(&mut rx, 10).await;
+
+        assert!(snap.boilers.healthy.contains_key(&3));
+        assert!(snap.boilers.unhealthy.is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn two_boilers_both_appear_in_snapshot() {
+        // grid → meter → [steam_boiler(3), steam_boiler(4)]
+        let mut pool = new_pool(MockComponent::grid(1).with_children(vec![
+            MockComponent::meter(2).with_children(vec![
+                MockComponent::steam_boiler(3).with_power(vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+                MockComponent::steam_boiler(4).with_power(vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+            ]),
+        ]))
+        .await;
+
+        let mut rx = pool.telemetry_snapshots();
+        let snap = last_snapshot(&mut rx, 10).await;
+
+        assert!(snap.boilers.healthy.contains_key(&3));
+        assert!(snap.boilers.healthy.contains_key(&4));
+        assert!(snap.boilers.unhealthy.is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn calling_telemetry_snapshots_twice_reuses_sender() {
+        let mut pool = new_pool(MockComponent::grid(1).with_children(vec![
+            MockComponent::meter(2).with_children(vec![
+                MockComponent::steam_boiler(3).with_power(vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+            ]),
+        ]))
+        .await;
+
+        let mut rx1 = pool.telemetry_snapshots();
+        let mut rx2 = pool.telemetry_snapshots();
+
+        // Advance so the tracker publishes at least one snapshot.
+        tokio::time::advance(std::time::Duration::from_millis(300)).await;
+
+        let snap1 = last_snapshot(&mut rx1, 0).await;
+        let snap2 = last_snapshot(&mut rx2, 0).await;
+        assert_eq!(
+            snap1, snap2,
+            "both subscriptions should observe the same snapshot"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn boiler_becomes_unhealthy_when_data_stops() {
+        // A handful of samples then silence; the stream stays open so the
+        // client actor doesn't reconnect and resupply data.
+        let mut pool = new_pool(MockComponent::grid(1).with_children(vec![
+            MockComponent::meter(2).with_children(vec![
+                MockComponent::steam_boiler(3)
+                    .with_power(vec![0.0, 0.0, 0.0])
+                    .with_silence_after_metrics(),
+            ]),
+        ]))
+        .await;
+
+        let mut rx = pool.telemetry_snapshots();
+
+        // First confirm the boiler reaches a healthy state.
+        let healthy = last_snapshot(&mut rx, 10).await;
+        assert!(
+            healthy.boilers.healthy.contains_key(&3),
+            "expected boiler to go healthy after initial samples, got {:?}",
+            healthy
+        );
+
+        // Advance well past the 10s missing-data tolerance — the component
+        // tracker should fire its interval and reclassify the boiler.
+        tokio::time::advance(std::time::Duration::from_secs(15)).await;
+        let unhealthy = last_snapshot(&mut rx, 5).await;
+
+        assert!(
+            unhealthy.boilers.healthy.is_empty(),
+            "boiler should be unhealthy after data stops, got healthy set {:?}",
+            unhealthy.boilers.healthy.keys()
+        );
+        assert!(unhealthy.boilers.unhealthy.contains_key(&3));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn boiler_with_error_state_is_unhealthy() {
+        // Boiler reports an Error state — it must land in the unhealthy set
+        // even though samples keep arriving.
+        let mut pool = new_pool(MockComponent::grid(1).with_children(vec![
+            MockComponent::meter(2).with_children(vec![
+                MockComponent::steam_boiler(3)
+                    .with_power(vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+                    .with_state(ElectricalComponentStateCode::Error),
+            ]),
+        ]))
+        .await;
+
+        let mut rx = pool.telemetry_snapshots();
+        let snap = last_snapshot(&mut rx, 10).await;
+
+        assert!(
+            !snap.boilers.healthy.contains_key(&3),
+            "boiler with Error state should not be in healthy set"
+        );
+        assert!(
+            snap.boilers.unhealthy.contains_key(&3),
+            "boiler with Error state should be in unhealthy set, got {:?}",
+            snap
+        );
+    }
+}


### PR DESCRIPTION
Adds steam boilers to the logical meter and as a pool, mirroring how PV inverters are handled.

## Changes

- `LogicalMeterHandle::steam_boiler::<M>()`: aggregation-only formula like CHP; the logical-meter test pins the formula strings and the consumer formula's new term.
- `SteamBoilerPool` via `Microgrid::steam_boiler_pool()`: power formula, aggregated active-power bounds, health-partitioned snapshots, same shape as `PvPool`. Healthy states are Ready and Charging only (Standby is not, unlike PV); see `boiler_with_bad_state_is_unhealthy`.
- The pool's telemetry tracker and bounds aggregator are deliberate copies of the PV ones with names changed. Sharing them is left for a follow-up PR, so existing PV and battery code is untouched here.
- `test-utils`: `MockComponent::steam_boiler()` and `add_power_bounds()`, the latter so pool bounds can be tested end to end.
- Release notes reset to the template (0.7.0 is tagged at the base) and the pre-existing "inclusion bounds" wording in the client docs replaced, since the v1 API has one kind of bounds.